### PR TITLE
[FEAT] 도별 리스트 출력 기능

### DIFF
--- a/app/src/main/java/com/nbcamp/tripgo/view/home/HomeFragment.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/home/HomeFragment.kt
@@ -28,9 +28,11 @@ import com.nbcamp.tripgo.util.extension.ContextExtension.toast
 import com.nbcamp.tripgo.view.App
 import com.nbcamp.tripgo.view.home.adapter.FestivalViewPagerAdapter
 import com.nbcamp.tripgo.view.home.adapter.NearbyPlaceAdapter
+import com.nbcamp.tripgo.view.home.adapter.ProvincePlaceListAdapter
 import com.nbcamp.tripgo.view.home.uistate.HomeFestivalUiState
 import com.nbcamp.tripgo.view.home.uistate.HomeNearbyPlaceUiState
 import com.nbcamp.tripgo.view.home.uistate.HomeWeatherUiState
+import com.nbcamp.tripgo.view.home.valuetype.ProvincePlaceEntity
 import com.nbcamp.tripgo.view.home.valuetype.TourTheme
 import com.nbcamp.tripgo.view.main.MainViewModel
 
@@ -66,6 +68,11 @@ class HomeFragment : Fragment() {
     private val nearbyPlaceAdapter by lazy {
         NearbyPlaceAdapter(requireActivity()) { contentId ->
             runTourDetailActivity(contentId)
+        }
+    }
+    private val provincePlaceListAdapter by lazy {
+        ProvincePlaceListAdapter(requireActivity()) { model ->
+            runAttractionActivity(model)
         }
     }
 
@@ -135,6 +142,9 @@ class HomeFragment : Fragment() {
             adapter = nearbyPlaceAdapter
             addOnScrollListener(endScrollListener)
         }
+        mainAllTourListRecyclerView.run {
+            adapter = provincePlaceListAdapter
+        }
     }
 
     private fun initViewModel() = with(homeViewModel) {
@@ -143,6 +153,7 @@ class HomeFragment : Fragment() {
             fetchViewPagerData()
             autoSlideViewPager()
             getPlaceByTodayWeather()
+            getProvincePlace()
         }
         checkLocationPermissions()
         festivalUiState.observe(viewLifecycleOwner) { state ->
@@ -177,10 +188,12 @@ class HomeFragment : Fragment() {
                 requireActivity().toast(getString(R.string.load_failed_data))
                 return@observe
             }
-            with(binding) {
-                nearbyProgressBar.isVisible = state.isLoading
-            }
+            binding.nearbyProgressBar.isVisible = state.isLoading
             nearbyPlaceAdapter.setList(state.list)
+        }
+        provincePlaceUiState.observe(viewLifecycleOwner) { state ->
+            binding.allTourProgressBar.isVisible = state.isLoading
+            provincePlaceListAdapter.submitList(state.list)
         }
     }
 
@@ -245,6 +258,10 @@ class HomeFragment : Fragment() {
 
     private fun runTourDetailActivity(contentId: String) {
         sharedViewModel.runTourDetailActivity(contentId)
+    }
+
+    private fun runAttractionActivity(model: ProvincePlaceEntity) {
+        sharedViewModel.runAttractionActivity(model)
     }
 
     private fun checkLocationPermissions() {

--- a/app/src/main/java/com/nbcamp/tripgo/view/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/home/HomeViewModel.kt
@@ -14,7 +14,10 @@ import com.nbcamp.tripgo.data.repository.model.TravelerEntity
 import com.nbcamp.tripgo.util.APIResponse
 import com.nbcamp.tripgo.view.home.uistate.HomeFestivalUiState
 import com.nbcamp.tripgo.view.home.uistate.HomeNearbyPlaceUiState
+import com.nbcamp.tripgo.view.home.uistate.HomeProvincePlaceUiState
 import com.nbcamp.tripgo.view.home.uistate.HomeWeatherUiState
+import com.nbcamp.tripgo.view.home.valuetype.AreaCode
+import com.nbcamp.tripgo.view.home.valuetype.ProvincePlaceEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
@@ -41,6 +44,10 @@ class HomeViewModel(
     private val _nearbyPlaceUiState: MutableLiveData<HomeNearbyPlaceUiState> = MutableLiveData()
     val nearbyPlaceUiState: LiveData<HomeNearbyPlaceUiState>
         get() = _nearbyPlaceUiState
+
+    private val _provincePlaceUiState: MutableLiveData<HomeProvincePlaceUiState> = MutableLiveData()
+    val provincePlaceUiState: LiveData<HomeProvincePlaceUiState>
+        get() = _provincePlaceUiState
 
     private val handler = Handler(Looper.getMainLooper()) {
         setPage()
@@ -136,7 +143,6 @@ class HomeViewModel(
         }
     }
 
-
     fun getNearbyPlaceList(location: Location?, pageNumber: Int) {
         _nearbyPlaceUiState.value = HomeNearbyPlaceUiState.initialize()
         viewModelScope.launch(Dispatchers.IO) {
@@ -171,6 +177,23 @@ class HomeViewModel(
                 }
             }
         }
+    }
+
+    fun getProvincePlace() {
+        _provincePlaceUiState.value = HomeProvincePlaceUiState.initialize()
+        val list = AreaCode.values().toList()
+        val provinceInfo = arrayListOf<ProvincePlaceEntity>()
+        list.forEach { areaCode ->
+            provinceInfo.add(
+                ProvincePlaceEntity(
+                    areaCode = areaCode.areaCode,
+                    name = areaCode.sido,
+                    tourListCount = areaCode.tourListCount,
+                    imageUrl = areaCode.defaultImageUrl
+                )
+            )
+        }
+        _provincePlaceUiState.value = HomeProvincePlaceUiState(provinceInfo, false)
     }
 
     // 위도 경도 사이 거리 계산 (m)

--- a/app/src/main/java/com/nbcamp/tripgo/view/home/adapter/ProvincePlaceListAdapter.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/home/adapter/ProvincePlaceListAdapter.kt
@@ -1,0 +1,72 @@
+package com.nbcamp.tripgo.view.home.adapter
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import coil.load
+import coil.request.CachePolicy
+import com.nbcamp.tripgo.R
+import com.nbcamp.tripgo.databinding.ItemMainTourCardBinding
+import com.nbcamp.tripgo.view.App
+import com.nbcamp.tripgo.view.home.valuetype.ProvincePlaceEntity
+import kotlin.math.floor
+
+class ProvincePlaceListAdapter(
+    private val context: Context,
+    private val onClickItem: (ProvincePlaceEntity) -> Unit
+) : ListAdapter<ProvincePlaceEntity, ProvincePlaceListAdapter.ProvincePlaceViewHolder>(DIFF_CALLBACK) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProvincePlaceViewHolder {
+        return ProvincePlaceViewHolder(
+            ItemMainTourCardBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            ),
+            onClickItem
+        )
+    }
+
+    override fun onBindViewHolder(holder: ProvincePlaceViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    inner class ProvincePlaceViewHolder(
+        private val binding: ItemMainTourCardBinding,
+        private val onClickItem: (ProvincePlaceEntity) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(model: ProvincePlaceEntity) = with(binding) {
+            itemView.setOnClickListener {
+                onClickItem(model)
+            }
+            itemTitleTextView.text = model.name
+            "${((floor(model.tourListCount.toDouble() / 100)) * 100).toInt()}${
+                context.getString(
+                    R.string.many_tour_place,
+                )
+            }".also { itemDescriptionTextView.text = it }
+            itemMainImageView.load(model.imageUrl, App.imageLoader) {
+                memoryCachePolicy(CachePolicy.ENABLED)
+                diskCachePolicy(CachePolicy.ENABLED)
+            }
+        }
+    }
+
+    companion object {
+        val DIFF_CALLBACK = object : DiffUtil.ItemCallback<ProvincePlaceEntity>() {
+            override fun areItemsTheSame(
+                oldItem: ProvincePlaceEntity,
+                newItem: ProvincePlaceEntity
+            ): Boolean = oldItem.areaCode == newItem.areaCode
+
+            override fun areContentsTheSame(
+                oldItem: ProvincePlaceEntity,
+                newItem: ProvincePlaceEntity
+            ): Boolean = oldItem == newItem
+        }
+    }
+}

--- a/app/src/main/java/com/nbcamp/tripgo/view/home/uistate/HomeProvincePlaceUiState.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/home/uistate/HomeProvincePlaceUiState.kt
@@ -1,0 +1,16 @@
+package com.nbcamp.tripgo.view.home.uistate
+
+import com.nbcamp.tripgo.view.home.valuetype.ProvincePlaceEntity
+
+data class HomeProvincePlaceUiState(
+    val list: List<ProvincePlaceEntity>?,
+    val isLoading: Boolean
+) {
+
+    companion object {
+        fun initialize() = HomeProvincePlaceUiState(
+            list = emptyList(),
+            isLoading = true
+        )
+    }
+}

--- a/app/src/main/java/com/nbcamp/tripgo/view/home/valuetype/AreaCode.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/home/valuetype/AreaCode.kt
@@ -1,22 +1,112 @@
 package com.nbcamp.tripgo.view.home.valuetype
 
 @Suppress("SpellCheckingInspection")
-enum class AreaCode(areaCode: String, name: String, tourListCount: Int) {
-    SEOUL("1", "서울시", 737),
-    INCHEON("2", "인천광역시", 423),
-    DAEJEON("3", "대전광역시", 132),
-    DAEGU("4", " 대구광역시", 312),
-    GWANGJU("5", "광주광역시", 161),
-    BUSAN("6", "부산광역시", 327),
-    ULSAN("7", "울산광역시", 172),
-    SEJONG("8", "세종시", 52),
-    GYEONGGI("31", " 경기도", 1548),
-    GANGWON("32", "강원도", 1371),
-    CHUNGBUK("33", "충청북도", 734),
-    CHUNGNAM("34", "충청남도", 855),
-    GYEONGBUK("35", "경상북도", 1290),
-    GYEONGNAM("36", "경상남도", 1372),
-    JEONBUK("37", " 전라북도", 976),
-    JEONNAM("38", " 전라남도", 1295),
-    JEJU("39", "제주도", 519),
+enum class AreaCode(
+    val areaCode: String,
+    val sido: String,
+    val tourListCount: Int,
+    val defaultImageUrl: String
+) {
+    SEOUL(
+        "1",
+        "서울시",
+        737,
+        "http://tong.visitkorea.or.kr/cms/resource/61/2780561_image2_1.png"
+    ),
+    INCHEON(
+        "2",
+        "인천광역시",
+        423,
+        "http://tong.visitkorea.or.kr/cms/resource/58/2781358_image2_1.jpg"
+    ),
+    DAEJEON(
+        "3",
+        "대전광역시",
+        132,
+        "http://tong.visitkorea.or.kr/cms/resource/71/1585671_image2_1.jpg"
+    ),
+    DAEGU(
+        "4",
+        "대구광역시",
+        312,
+        "http://tong.visitkorea.or.kr/cms/resource/70/1876170_image2_1.jpg"
+    ),
+    GWANGJU(
+        "5",
+        "광주광역시",
+        161,
+        "http://tong.visitkorea.or.kr/cms/resource/19/1587419_image2_1.jpg"
+    ),
+    BUSAN(
+        "6",
+        "부산광역시",
+        327,
+        "http://tong.visitkorea.or.kr/cms/resource/61/2716261_image2_1.jpg"
+    ),
+    ULSAN(
+        "7",
+        "울산광역시",
+        172,
+        "http://tong.visitkorea.or.kr/cms/resource/17/2038117_image2_1.jpg"
+    ),
+    SEJONG(
+        "8",
+        "세종시",
+        52,
+        "http://tong.visitkorea.or.kr/cms/resource/57/2812357_image2_1.jpg"
+    ),
+    GYEONGGI(
+        "31",
+        "경기도",
+        1548,
+        "http://tong.visitkorea.or.kr/cms/resource/46/2010746_image2_1.jpg"
+    ),
+    GANGWON(
+        "32",
+        "강원도",
+        1371,
+        "http://tong.visitkorea.or.kr/cms/resource/54/2994054_image2_1.jpg"
+    ),
+    CHUNGBUK(
+        "33",
+        "충청북도",
+        734,
+        "http://tong.visitkorea.or.kr/cms/resource/92/1075092_image2_1.jpg"
+    ),
+    CHUNGNAM(
+        "34",
+        "충청남도",
+        855,
+        "http://tong.visitkorea.or.kr/cms/resource/87/2648687_image2_1.jpg"
+    ),
+    GYEONGBUK(
+        "35",
+        "경상북도",
+        1290,
+        "http://tong.visitkorea.or.kr/cms/resource/86/2687486_image2_1.jpg"
+    ),
+    GYEONGNAM(
+        "36",
+        "경상남도",
+        1372,
+        "http://tong.visitkorea.or.kr/cms/resource/55/2033255_image2_1.jpg"
+    ),
+    JEONBUK(
+        "37",
+        "전라북도",
+        976,
+        "http://tong.visitkorea.or.kr/cms/resource/72/1604272_image2_1.jpg"
+    ),
+    JEONNAM(
+        "38",
+        "전라남도",
+        1295,
+        "http://tong.visitkorea.or.kr/cms/resource/17/1608017_image2_1.jpg"
+    ),
+    JEJU(
+        "39",
+        "제주도",
+        519,
+        "http://tong.visitkorea.or.kr/cms/resource/01/1884201_image2_1.jpg"
+    ),
 }

--- a/app/src/main/java/com/nbcamp/tripgo/view/home/valuetype/AreaCode.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/home/valuetype/AreaCode.kt
@@ -1,0 +1,22 @@
+package com.nbcamp.tripgo.view.home.valuetype
+
+@Suppress("SpellCheckingInspection")
+enum class AreaCode(areaCode: String, name: String, tourListCount: Int) {
+    SEOUL("1", "서울시", 737),
+    INCHEON("2", "인천광역시", 423),
+    DAEJEON("3", "대전광역시", 132),
+    DAEGU("4", " 대구광역시", 312),
+    GWANGJU("5", "광주광역시", 161),
+    BUSAN("6", "부산광역시", 327),
+    ULSAN("7", "울산광역시", 172),
+    SEJONG("8", "세종시", 52),
+    GYEONGGI("31", " 경기도", 1548),
+    GANGWON("32", "강원도", 1371),
+    CHUNGBUK("33", "충청북도", 734),
+    CHUNGNAM("34", "충청남도", 855),
+    GYEONGBUK("35", "경상북도", 1290),
+    GYEONGNAM("36", "경상남도", 1372),
+    JEONBUK("37", " 전라북도", 976),
+    JEONNAM("38", " 전라남도", 1295),
+    JEJU("39", "제주도", 519),
+}

--- a/app/src/main/java/com/nbcamp/tripgo/view/home/valuetype/ProvincePlaceEntity.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/home/valuetype/ProvincePlaceEntity.kt
@@ -1,0 +1,12 @@
+package com.nbcamp.tripgo.view.home.valuetype
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class ProvincePlaceEntity(
+    val areaCode: String,
+    val name: String,
+    val tourListCount: Int,
+    val imageUrl: String
+) : Parcelable

--- a/app/src/main/java/com/nbcamp/tripgo/view/main/MainActivity.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/main/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.nbcamp.tripgo.R
 import com.nbcamp.tripgo.databinding.ActivityMainBinding
+import com.nbcamp.tripgo.view.attraction.AttractionsActivity
 import com.nbcamp.tripgo.view.calendar.CalendarFragment
 import com.nbcamp.tripgo.view.home.HomeFragment
 import com.nbcamp.tripgo.view.home.valuetype.TourTheme
@@ -88,6 +89,17 @@ class MainActivity : AppCompatActivity() {
                             TourDetailActivity::class.java
                         ).apply {
                             putExtra("contentId", themeClickEvent.contentId)
+                        }
+                    )
+                }
+
+                is ThemeClickEvent.RunAttractionActivity -> {
+                    startActivity(
+                        Intent(
+                            this@MainActivity,
+                            AttractionsActivity::class.java
+                        ).apply {
+                            putExtra("provinceModel", themeClickEvent.model)
                         }
                     )
                 }

--- a/app/src/main/java/com/nbcamp/tripgo/view/main/MainViewModel.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/main/MainViewModel.kt
@@ -3,6 +3,7 @@ package com.nbcamp.tripgo.view.main
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import com.nbcamp.tripgo.util.SingleLiveEvent
+import com.nbcamp.tripgo.view.home.valuetype.ProvincePlaceEntity
 import com.nbcamp.tripgo.view.home.valuetype.TourTheme
 
 class MainViewModel : ViewModel() {
@@ -15,5 +16,9 @@ class MainViewModel : ViewModel() {
 
     fun runTourDetailActivity(contentId: String) {
         _event.value = ThemeClickEvent.RunTourDetailActivity(contentId)
+    }
+
+    fun runAttractionActivity(model: ProvincePlaceEntity) {
+        _event.value = ThemeClickEvent.RunAttractionActivity(model)
     }
 }

--- a/app/src/main/java/com/nbcamp/tripgo/view/main/ThemeClickEvent.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/main/ThemeClickEvent.kt
@@ -1,5 +1,6 @@
 package com.nbcamp.tripgo.view.main
 
+import com.nbcamp.tripgo.view.home.valuetype.ProvincePlaceEntity
 import com.nbcamp.tripgo.view.home.valuetype.TourTheme
 
 sealed interface ThemeClickEvent {
@@ -10,5 +11,9 @@ sealed interface ThemeClickEvent {
 
     data class RunTourDetailActivity(
         val contentId: String
+    ) : ThemeClickEvent
+
+    data class RunAttractionActivity(
+        val model: ProvincePlaceEntity
     ) : ThemeClickEvent
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,4 +120,5 @@
     <string name="disagree_permission">취소</string>
     <string name="in_1km">1km 이내</string>
     <string name="in_km">km 이내</string>
+    <string name="many_tour_place">곳 이상의 관광지</string>
 </resources>


### PR DESCRIPTION
도별 리스트를 출력하는 기능, 클릭 이벤트시 Attractions Activity로 전환하는 기능을 구현하였습니다.

Atractions Activity에서는 

```kotlin
val model = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
     intent?.getParcelableExtra("provinceModel", ProvincePlaceEntity::class.java)
} else {
     intent?.getParcelableExtra("provinceModel")
}
```
위 처럼 model값을 받고 지역기반 검색 api의 areaCode에 model.areaCode를 넣고 contentTypeId엔 12를 넣어 데이터를 가져온 후 데이터를 리사이클러뷰에 뿌리면 됩니다.