### PR TITLE
[FEAT] 캘린더 프래그먼트에서의 일정 삭제 및 수정 기능 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,6 +56,9 @@
             android:name=".view.tour.detail.TourDetailActivity"
             android:exported="false" />
         <activity
+            android:name=".view.calendar.modify.TourModifyDetailActivity"
+            android:exported="false" />
+        <activity
             android:name=".view.search.SearchActivity"
             android:exported="true" />
         <activity

--- a/app/src/main/java/com/nbcamp/tripgo/data/repository/CalendarRepositoryImpl.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/data/repository/CalendarRepositoryImpl.kt
@@ -30,10 +30,10 @@ class CalendarRepositoryImpl(
 //        else if (firebaseAuth.currentUser == null && kaKaoAccount != null)
 //            return kaKaoAccount
 //        return null
-        if (App.kaKaoUser == null)
+        if (App.kakaoUser == null)
             return App.firebaseUser
         else if (App.firebaseUser == null)
-            return App.kaKaoUser
+            return App.kakaoUser
         return null
     }
 
@@ -52,7 +52,7 @@ class CalendarRepositoryImpl(
 
     override suspend fun deleteSchedule(id: String): List<CalendarEntity> {
         val email = if (App.firebaseUser == null) {
-            App.kaKaoUser?.email
+            App.kakaoUser?.email
         } else {
             App.firebaseUser?.email
         }
@@ -84,7 +84,7 @@ class CalendarRepositoryImpl(
         endDate: String
     ): List<CalendarEntity> {
         val email = if (App.firebaseUser == null) {
-            App.kaKaoUser?.email
+            App.kakaoUser?.email
         } else {
             App.firebaseUser?.email
         }

--- a/app/src/main/java/com/nbcamp/tripgo/data/repository/ReviewWritingRepositoryImpl.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/data/repository/ReviewWritingRepositoryImpl.kt
@@ -37,10 +37,10 @@ class ReviewWritingRepositoryImpl : ReviewWritingRepository {
 //                userInfo = user.email.toString()
 //            }
 //        }
-        if (App.kaKaoUser == null) {
+        if (App.kakaoUser == null) {
             userInfo = App.firebaseUser?.email.toString()
         } else if (App.firebaseUser == null) {
-            userInfo = App.kaKaoUser?.email.toString()
+            userInfo = App.kakaoUser?.email.toString()
         }
 
         fileName = "${userInfo.split("@").first()}_${calendarUserModel.model?.id}.png"

--- a/app/src/main/java/com/nbcamp/tripgo/data/repository/TourDetailRepositoryImpl.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/data/repository/TourDetailRepositoryImpl.kt
@@ -174,10 +174,10 @@ class TourDetailRepositoryImpl(
     }
 
     private fun getUserInfo() {
-        if (App.kaKaoUser == null) {
+        if (App.kakaoUser == null) {
             userInfo = App.firebaseUser?.email.toString()
         } else if (App.firebaseUser == null) {
-            userInfo = App.kaKaoUser?.email.toString()
+            userInfo = App.kakaoUser?.email.toString()
         }
     }
 

--- a/app/src/main/java/com/nbcamp/tripgo/data/repository/model/CalendarEntity.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/data/repository/model/CalendarEntity.kt
@@ -9,8 +9,8 @@ data class CalendarEntity(
     @DocumentId
     val id: String? = null,
     val contentId: String? = null,
-    val startDate: String? = null,
-    val endDate: String? = null,
+    var startDate: String? = null,
+    var endDate: String? = null,
     val title: String? = null,
     val description: String? = null,
     val telPhone: String? = null,
@@ -18,4 +18,19 @@ data class CalendarEntity(
     val homePage: String? = null,
     @field:JvmField
     val isReviewed: Boolean? = null
-) : Parcelable
+) : Parcelable {
+    fun toMap(): Map<String, Any?> {
+        return mapOf(
+            "address" to address,
+            "contentId" to contentId,
+            "description" to description,
+            "endDate" to endDate,
+            "homePage" to homePage,
+            "isReviewed" to isReviewed,
+            "startDate" to startDate,
+            "telPhone" to telPhone,
+            "title" to title
+        )
+    }
+}
+

--- a/app/src/main/java/com/nbcamp/tripgo/data/repository/model/CalendarEntity.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/data/repository/model/CalendarEntity.kt
@@ -1,7 +1,10 @@
 package com.nbcamp.tripgo.data.repository.model
 
+import android.os.Parcelable
 import com.google.firebase.firestore.DocumentId
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 data class CalendarEntity(
     @DocumentId
     val id: String? = null,
@@ -15,4 +18,4 @@ data class CalendarEntity(
     val homePage: String? = null,
     @field:JvmField
     val isReviewed: Boolean? = null
-)
+) : Parcelable

--- a/app/src/main/java/com/nbcamp/tripgo/util/SwipeToEditCallback.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/util/SwipeToEditCallback.kt
@@ -1,0 +1,82 @@
+package com.nbcamp.tripgo.util
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffXfermode
+import android.graphics.drawable.ColorDrawable
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.ItemTouchHelper
+import androidx.recyclerview.widget.RecyclerView
+import com.nbcamp.tripgo.R
+
+abstract class SwipeToEditCallback(context: Context) :
+    ItemTouchHelper.SimpleCallback(0, ItemTouchHelper.RIGHT) {
+
+    private val editIcon = ContextCompat.getDrawable(context, R.drawable.icon_schedule_modify)
+    private val intrinsicWidth = editIcon!!.intrinsicWidth
+    private val intrinsicHeight = editIcon!!.intrinsicHeight
+    private val background = ColorDrawable()
+    private val backgroundColor = Color.parseColor("#24ae05")
+    private val clearPaint = Paint().apply { xfermode = PorterDuffXfermode(PorterDuff.Mode.CLEAR) }
+    override fun onMove(
+        recyclerView: RecyclerView,
+        viewHolder: RecyclerView.ViewHolder,
+        target: RecyclerView.ViewHolder
+    ): Boolean {
+        return false
+    }
+
+    override fun onChildDraw(
+        c: Canvas,
+        recyclerView: RecyclerView,
+        viewHolder: RecyclerView.ViewHolder,
+        dX: Float,
+        dY: Float,
+        actionState: Int,
+        isCurrentlyActive: Boolean
+    ) {
+
+        super.onChildDraw(c, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive)
+        val itemView = viewHolder.itemView
+        val itemHeight = itemView.bottom - itemView.top
+        val isCanceled = dX == 0f && !isCurrentlyActive
+
+        if (isCanceled) {
+            clearCanvas(
+                c,
+                itemView.left + dX,
+                itemView.top.toFloat(),
+                itemView.left.toFloat(),
+                itemView.bottom.toFloat()
+            )
+            super.onChildDraw(c, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive)
+            return
+        }
+        // Draw the green edit background
+        background.color = backgroundColor
+        background.setBounds(
+            itemView.left + dX.toInt(),
+            itemView.top,
+            itemView.left,
+            itemView.bottom
+        )
+        background.draw(c)
+
+        // Calculate position of edit icon
+        val editIconTop = itemView.top + (itemHeight - intrinsicHeight) / 2
+        val editIconLeft = itemView.left + itemHeight - intrinsicWidth
+        val editIconRight = itemView.left + itemHeight
+        val editIconBottom = editIconTop + intrinsicHeight
+
+        // Draw the icon
+        editIcon!!.setBounds(editIconLeft, editIconTop, editIconRight, editIconBottom)
+        editIcon.draw(c)
+    }
+
+    private fun clearCanvas(c: Canvas?, left: Float, top: Float, right: Float, bottom: Float) {
+        c?.drawRect(left, top, right, bottom, clearPaint)
+    }
+}

--- a/app/src/main/java/com/nbcamp/tripgo/util/calendar/CalendarFragmentTodayDecorator.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/util/calendar/CalendarFragmentTodayDecorator.kt
@@ -1,0 +1,20 @@
+package com.nbcamp.tripgo.util.calendar
+
+import android.content.Context
+import androidx.core.content.ContextCompat
+import com.nbcamp.tripgo.R
+import com.prolificinteractive.materialcalendarview.CalendarDay
+import com.prolificinteractive.materialcalendarview.DayViewDecorator
+import com.prolificinteractive.materialcalendarview.DayViewFacade
+
+class CalendarFragmentTodayDecorator(context: Context) : DayViewDecorator {
+    private val drawable = ContextCompat.getDrawable(context, R.drawable.calendar_today_circle)
+    private var date = CalendarDay.today()
+    override fun shouldDecorate(day: CalendarDay?): Boolean {
+        return day?.equals(date)!!
+    }
+
+    override fun decorate(view: DayViewFacade?) {
+        view?.setBackgroundDrawable(drawable!!)
+    }
+}

--- a/app/src/main/java/com/nbcamp/tripgo/util/extension/StringExtension.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/util/extension/StringExtension.kt
@@ -1,0 +1,12 @@
+package com.nbcamp.tripgo.util.extension
+
+import com.prolificinteractive.materialcalendarview.CalendarDay
+
+object StringExtension {
+    fun String.toCalendarDay(): CalendarDay {
+        val (year, date) = this.chunked(4).map { it }
+        val (month, day) = date.chunked(2).map { it.toInt() }
+
+        return CalendarDay.from(year.toInt(), month, day)
+    }
+}

--- a/app/src/main/java/com/nbcamp/tripgo/view/calendar/CalendarFragment.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/calendar/CalendarFragment.kt
@@ -14,6 +14,7 @@ import com.nbcamp.tripgo.R
 import com.nbcamp.tripgo.data.repository.model.CalendarEntity
 import com.nbcamp.tripgo.databinding.FragmentCalendarBinding
 import com.nbcamp.tripgo.util.LoadingDialog
+import com.nbcamp.tripgo.util.calendar.CalendarFragmentTodayDecorator
 import com.nbcamp.tripgo.util.calendar.OutDateMonthDecorator
 import com.nbcamp.tripgo.util.calendar.SaturdayDecorator
 import com.nbcamp.tripgo.util.calendar.SelectedDayDecorator
@@ -114,7 +115,7 @@ class CalendarFragment : Fragment() {
                         SaturdayDecorator(month, 1),
                         SundayDecorator(month, 1),
                         OutDateMonthDecorator(requireActivity(), month + 1),
-                        TodayDecorator(requireActivity())
+                        CalendarFragmentTodayDecorator(requireActivity())
                     )
                 }
             }

--- a/app/src/main/java/com/nbcamp/tripgo/view/calendar/CalendarRepository.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/calendar/CalendarRepository.kt
@@ -20,4 +20,17 @@ interface CalendarRepository {
      * @return 사용자의 일정 목록
      */
     suspend fun deleteSchedule(id: String): List<CalendarEntity>
+
+    /**
+     *  @param entity 수정 할 일정 모델
+     *  @param startDate 수정 할 시작 일
+     *  @param endDate 수정 할 종료 일
+     *
+     *  @return 업데이트 된 일정 목록
+     */
+    suspend fun modifySchedule(
+        entity: CalendarEntity,
+        startDate: String,
+        endDate: String
+    ): List<CalendarEntity>
 }

--- a/app/src/main/java/com/nbcamp/tripgo/view/calendar/CalendarRepository.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/calendar/CalendarRepository.kt
@@ -14,4 +14,10 @@ interface CalendarRepository {
      *  @return 사용자의 일정 목록
      */
     suspend fun getMySchedules(email: String): List<CalendarEntity>
+
+    /**
+     * @param id 삭제할 일정 문서 아이디
+     * @return 사용자의 일정 목록
+     */
+    suspend fun deleteSchedule(id: String): List<CalendarEntity>
 }

--- a/app/src/main/java/com/nbcamp/tripgo/view/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/calendar/CalendarViewModel.kt
@@ -45,9 +45,14 @@ class CalendarViewModel(
     val deleteScheduleUiState: MutableLiveData<CalendarScheduleUiState>
         get() = _deleteScheduleUiState
 
+    // 일정 수정 시 캘린더 클릭 이벤트를 처리할 라이브 데이터
+    private val _calendarClickModifyEvent: SingleLiveEvent<Boolean> = SingleLiveEvent()
+    val calendarClickModifyEvent: SingleLiveEvent<Boolean>
+        get() = _calendarClickModifyEvent
+
     // 원본으로 하기 힘든 위치에 추가적인 날짜 필터링을 위해 캐싱 데이터를 생성
     private var cachingSchedule: List<CalendarEntity>? = null
-
+    private val scheduleDates = arrayListOf<CalendarDay>()
     fun getLoginStatus() {
         val currentUser = calendarRepository.getCurrentUser()
         when (currentUser) {
@@ -182,6 +187,26 @@ class CalendarViewModel(
                 ?.first() == changedMonth.toString()
         }
         _changedMonthState.value = filteredSchedule?.sortedBy { it.startDate?.toInt() }
+    }
+
+    // 수정 날짜를 제한하기 위한 함수
+    fun selectScheduleRange(dates: List<CalendarDay>, selectedDayList: List<CalendarDay>) {
+        if (dates.last().isBefore(CalendarDay.today())) {
+            // 선택한 범위가 오늘 보다 전이면, 선택을 못 하도록 막음
+            scheduleDates.clear()
+            _calendarClickModifyEvent.value = false
+            return
+        }
+        if (dates.intersect(selectedDayList.toSet()).isNotEmpty()) {
+            // 겹치는 부분이 있으면 이전 저장 되어 있던 것 제거
+            // 제거 안하면 확인 클릭 했을 때 isEmpty 를 통과 하여 이상 현상 발생
+            scheduleDates.clear()
+            _calendarClickModifyEvent.value = true
+            return
+        }
+
+        scheduleDates.clear()
+        scheduleDates.addAll(dates)
     }
 
     fun runDialogForReviewWriting(

--- a/app/src/main/java/com/nbcamp/tripgo/view/calendar/ScheduleListAdapter.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/calendar/ScheduleListAdapter.kt
@@ -13,7 +13,8 @@ import com.nbcamp.tripgo.databinding.ItemCalendarScheduleCardBinding
 import java.util.Locale
 
 class ScheduleListAdapter(
-    private val onClickItem: (CalendarEntity) -> Unit
+    private val onClickItem: (CalendarEntity) -> Unit,
+    private val onLongClickItem: (CalendarEntity) -> Unit,
 ) : ListAdapter<CalendarEntity, ScheduleListAdapter.ScheduleViewHolder>(DIFF_CALLBACK) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ScheduleViewHolder {
@@ -23,7 +24,8 @@ class ScheduleListAdapter(
                 parent,
                 false
             ),
-            onClickItem
+            onClickItem,
+            onLongClickItem
         )
     }
 
@@ -33,7 +35,8 @@ class ScheduleListAdapter(
 
     inner class ScheduleViewHolder(
         private val binding: ItemCalendarScheduleCardBinding,
-        private val onClickItem: (CalendarEntity) -> Unit
+        private val onClickItem: (CalendarEntity) -> Unit,
+        private val onLongClickItem: (CalendarEntity) -> Unit
     ) : RecyclerView.ViewHolder(binding.root) {
         private val today = Calendar.getInstance(Locale.KOREA)
         private val year = today.get(Calendar.YEAR)
@@ -54,6 +57,10 @@ class ScheduleListAdapter(
                 itemView.setOnClickListener {
                     onClickItem(model)
                 }
+            }
+            itemView.setOnLongClickListener {
+                onLongClickItem(model)
+                true
             }
             itemCheckTextView.isVisible = isValid
             defaultSetting(model)

--- a/app/src/main/java/com/nbcamp/tripgo/view/calendar/ScheduleModifyFragment.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/calendar/ScheduleModifyFragment.kt
@@ -1,0 +1,178 @@
+package com.nbcamp.tripgo.view.calendar
+
+import android.os.Build
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
+import com.nbcamp.tripgo.R
+import com.nbcamp.tripgo.data.repository.model.CalendarEntity
+import com.nbcamp.tripgo.databinding.DialogCalendarBinding
+import com.nbcamp.tripgo.util.LoadingDialog
+import com.nbcamp.tripgo.util.calendar.CalendarFragmentTodayDecorator
+import com.nbcamp.tripgo.util.calendar.CantSetDayDecorator
+import com.nbcamp.tripgo.util.calendar.OutDateMonthDecorator
+import com.nbcamp.tripgo.util.calendar.SaturdayDecorator
+import com.nbcamp.tripgo.util.calendar.SundayDecorator
+import com.nbcamp.tripgo.util.calendar.TodayDecorator
+import com.nbcamp.tripgo.util.extension.ContextExtension.toast
+import com.prolificinteractive.materialcalendarview.CalendarDay
+import java.util.Calendar
+
+class ScheduleModifyFragment : DialogFragment() {
+    private var _binding: DialogCalendarBinding? = null
+    private val binding: DialogCalendarBinding
+        get() = _binding!!
+    private var loadingDialog: LoadingDialog? = null
+    private var entity: CalendarEntity? = null
+    private var selectedDayList: ArrayList<CalendarDay>? = null
+    private var forModifySchedule: ArrayList<CalendarEntity>? = null
+    private val month = Calendar.getInstance().get(Calendar.MONTH)
+    private val calendarViewModel: CalendarViewModel by viewModels {
+        CalendarViewModelFactory(
+            requireActivity()
+        )
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = DialogCalendarBinding.inflate(layoutInflater)
+        loadingDialog = LoadingDialog(requireActivity())
+        return binding.root
+    }
+
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        entity = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arguments?.getParcelable("model", CalendarEntity::class.java)
+        } else {
+            arguments?.getParcelable("model")
+        }
+        selectedDayList = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arguments?.getParcelableArrayList("selectedDayList", CalendarDay::class.java)
+        } else {
+            arguments?.getParcelable("selectedDayList")
+        }
+        forModifySchedule = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arguments?.getParcelableArrayList("forModifySchedule", CalendarEntity::class.java)
+        } else {
+            arguments?.getParcelable("forModifySchedule")
+        }
+        initViews()
+        initViewModel()
+    }
+
+
+    private fun initViews() = with(binding) {
+        negativeTextView.setOnClickListener {
+            val fragment = parentFragmentManager.findFragmentByTag(TAG)
+            if (fragment != null) {
+                val dialogFragment = fragment as DialogFragment
+                dialogFragment.dismiss()
+            }
+        }
+        entity?.let {
+            setCalendarOption(it)
+        }
+        runModifySchedule()
+
+    }
+
+    private fun initViewModel() = with(calendarViewModel) {
+        with(binding) {
+            // start ~ end date 사이의 기간을 달력에 표시
+            schedulesDateState.observe(viewLifecycleOwner) { dateList ->
+                // 일정이 있는 날엔 달력에 따로 표시해 주기 위한 리스트
+                selectedDayList?.clear()
+                selectedDayList?.addAll(dateList)
+
+                addScheduleCalendarView.run {
+                    removeDecorators()
+                    invalidateDecorators()
+                    addDecorators(
+                        SaturdayDecorator(month, 1),
+                        SundayDecorator(month, 1),
+                        OutDateMonthDecorator(requireActivity(), month + 1),
+                        CalendarFragmentTodayDecorator(requireActivity()),
+                        selectedDayList?.let {
+                            CantSetDayDecorator(requireActivity(), it)
+                        }
+                    )
+                }
+
+            }
+
+            calendarClickModifyEvent.observe(requireActivity()) {
+                when (it) {
+                    true -> requireActivity().toast(getString(R.string.cant_select_duplicate_schedule))
+                    false -> requireActivity().toast(getString(R.string.not_register_schedule_before_today))
+                }
+                binding.addScheduleCalendarView.clearSelection()
+            }
+        }
+    }
+
+    private fun setCalendarOption(model: CalendarEntity) = with(binding) {
+        if (selectedDayList == null) {
+            return
+        }
+        // 다이얼로그에 보여줄 스케줄은 현재 선택한 스케줄을 제외하고 선택할 수 있도록 함
+        val filteredSchedule =
+            forModifySchedule?.filter { it.endDate != model.endDate }
+        calendarViewModel.setSelectedDate(filteredSchedule)
+        addScheduleCalendarView.run {
+            val month = Calendar.getInstance().get(Calendar.MONTH)
+            removeDecorators()
+            invalidateDecorators()
+            addDecorators(
+                SaturdayDecorator(month, 1),
+                SundayDecorator(month, 1),
+                OutDateMonthDecorator(requireActivity(), month + 1),
+                TodayDecorator(requireActivity()),
+                CantSetDayDecorator(requireActivity(), selectedDayList!!)
+            )
+            setOnMonthChangedListener { _, date ->
+                removeDecorators()
+                invalidateDecorators()
+                addDecorators(
+                    SaturdayDecorator(date.month, 0),
+                    SundayDecorator(date.month, 0),
+                    TodayDecorator(requireActivity()),
+                    OutDateMonthDecorator(requireActivity(), date.month),
+                    CantSetDayDecorator(requireActivity(), selectedDayList!!)
+                )
+            }
+            setOnRangeSelectedListener { _, dates ->
+                calendarViewModel.selectScheduleRange(dates, selectedDayList!!)
+            }
+            setOnDateChangedListener { _, date, _ ->
+                // 사용자는 하루만 선택을 할 수도 있으므로 단일 처리도 해야함
+                val dates = listOf(date, date)
+                calendarViewModel.selectScheduleRange(dates, selectedDayList!!)
+            }
+        }
+    }
+
+    private fun runModifySchedule() {
+        binding.calendarProgressBar.isVisible = false
+
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+        loadingDialog = null
+    }
+
+    companion object {
+        const val TAG = "SCHEDULE_DIALOG_FRAGMENT"
+        fun newInstance(): DialogFragment = ScheduleModifyFragment()
+    }
+}

--- a/app/src/main/java/com/nbcamp/tripgo/view/calendar/modify/TourModifyDetailActivity.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/calendar/modify/TourModifyDetailActivity.kt
@@ -1,0 +1,389 @@
+package com.nbcamp.tripgo.view.calendar.modify
+
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.text.TextUtils
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
+import androidx.core.content.res.ResourcesCompat
+import androidx.core.view.isVisible
+import coil.load
+import com.google.android.material.snackbar.Snackbar
+import com.nbcamp.tripgo.BuildConfig
+import com.nbcamp.tripgo.R
+import com.nbcamp.tripgo.data.repository.model.CalendarEntity
+import com.nbcamp.tripgo.data.repository.model.DetailCommonEntity
+import com.nbcamp.tripgo.databinding.ActivityTourDetailBinding
+import com.nbcamp.tripgo.util.LoadingDialog
+import com.nbcamp.tripgo.util.TMapFrameLayout
+import com.nbcamp.tripgo.util.extension.ContextExtension.toast
+import com.nbcamp.tripgo.view.App
+import com.nbcamp.tripgo.view.calendar.ScheduleModifyFragment
+import com.nbcamp.tripgo.view.main.MainActivity
+import com.nbcamp.tripgo.view.tour.detail.TextClickEvent
+import com.nbcamp.tripgo.view.tour.detail.TourDetailViewModel
+import com.nbcamp.tripgo.view.tour.detail.TourDetailViewModelFactory
+import com.nbcamp.tripgo.view.tour.detail.uistate.DetailCommonUiState
+import com.prolificinteractive.materialcalendarview.CalendarDay
+import com.skt.tmap.TMapPoint
+import com.skt.tmap.TMapView
+import com.skt.tmap.overlay.TMapMarkerItem
+
+class TourModifyDetailActivity : AppCompatActivity() {
+    private var startDate: CalendarDay? = null
+    private var endDate: CalendarDay? = null
+    private var contentId: String? = null
+    private lateinit var binding: ActivityTourDetailBinding
+    private lateinit var loadingDialog: LoadingDialog
+    private var entity: CalendarEntity? = null
+    private var selectedDayList: List<CalendarDay>? = null
+    private var forModifySchedule: ArrayList<CalendarEntity>? = null
+    private lateinit var detailInfo: DetailCommonEntity
+    private lateinit var container: TMapFrameLayout
+    private lateinit var tMapView: TMapView
+    private var currentUser: Any? = null
+
+
+    private val tourDetailViewModel: TourDetailViewModel by viewModels {
+        TourDetailViewModelFactory(
+            this
+        )
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityTourDetailBinding.inflate(layoutInflater)
+        loadingDialog = LoadingDialog(this)
+        container = binding.routeMap
+        setContentView(binding.root)
+
+        initVariables()
+        initViews()
+        initViewModel()
+    }
+
+    private fun initVariables() {
+        loadingDialog = LoadingDialog(this)
+        startDate = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent?.getParcelableExtra("startDate", CalendarDay::class.java)
+        } else {
+            intent?.getParcelableExtra("startDate")
+        }
+
+        endDate = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent?.getParcelableExtra("endDate", CalendarDay::class.java)
+        } else {
+            intent?.getParcelableExtra("endDate")
+        }
+        contentId = intent?.getStringExtra("contentId")
+        entity = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent?.getParcelableExtra("model", CalendarEntity::class.java)
+        } else {
+            intent?.getParcelableExtra("model")
+        }
+        selectedDayList = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent?.getParcelableArrayListExtra("selectedDayList", CalendarDay::class.java)
+        } else {
+            intent?.getParcelableArrayListExtra("selectedDayList")
+        }
+        forModifySchedule = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent?.getParcelableArrayListExtra("forModifySchedule", CalendarEntity::class.java)
+        } else {
+            intent?.getParcelableArrayListExtra("forModifySchedule")
+        }
+    }
+
+    private fun initViews() = with(binding) {
+        val contentId = contentId
+        moveToCalendar.run {
+            text = "일정 수정하기"
+            setTextColor(ResourcesCompat.getColor(resources, R.color.black, theme))
+        }
+        btnBack.setOnClickListener {
+            finish()
+        }
+        phoneNumber.setOnClickListener {
+            tourDetailViewModel.makeCall()
+        }
+        moveToHomepage.setOnClickListener {
+            tourDetailViewModel.moveToHomePage()
+        }
+        btnHeart.setOnClickListener {
+            // 좋아요 저장 및 삭제
+            if (currentUser != null) {
+                // 좋아요 버튼 상태 조작
+                it.isSelected = it.isSelected.not()
+                if (it.isSelected) {
+                    tourDetailViewModel.saveLikePlace(detailInfo, contentId, currentUser!!)
+                    return@setOnClickListener
+                }
+                tourDetailViewModel.removeLikePlace(contentId, currentUser)
+            } else {
+                toast(getString(R.string.not_login_then_not_submit_like))
+            }
+
+        }
+        // 일정 추가 캘린더 다이얼로그 실행
+        moveToCalendar.setOnClickListener {
+            val bundle = Bundle().apply {
+                putParcelable("model", entity)
+                putParcelableArrayList(
+                    "selectedDayList",
+                    selectedDayList?.let { ArrayList(it) }
+                )
+                putParcelableArrayList(
+                    "forModifySchedule",
+                    forModifySchedule?.let { ArrayList(it) }
+                )
+            }
+            ScheduleModifyFragment.newInstance().apply {
+                arguments = bundle
+            }.show(supportFragmentManager, ScheduleModifyFragment.TAG)
+
+        }
+        // 상단 홈 버튼 클릭 시 메인으로 이동
+        btnHome.setOnClickListener {
+            startActivity(Intent(this@TourModifyDetailActivity, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
+            })
+        }
+        // 공유 버튼
+        btnShare.setOnClickListener {
+            sharingPlace()
+        }
+        when {
+            CalendarDay.today().isInRange(startDate, endDate) -> {
+                moveToCalendar.run {
+                    text = getString(R.string.now_doing_schedule_cant_modify)
+                    setTextColor(resources.getColor(R.color.black, theme))
+                    isEnabled = false
+                }
+            }
+
+            endDate?.isBefore(CalendarDay.today()) == true -> {
+                moveToCalendar.run {
+                    text = getString(R.string.past_schedule_not_modify)
+                    setTextColor(resources.getColor(R.color.black, theme))
+                    isEnabled = false
+                }
+            }
+        }
+
+        // 지도 위에서 스크롤 뷰의 이벤트를 막기 위한 함수
+        doNotFrameScroll()
+        // 상세 정보 가져오기
+        runSearchDetailInformation(contentId)
+    }
+
+    private fun runSearchDetailInformation(contentId: String?) {
+        // 관광지 상세 정보 및 리뷰에서 평점 가져오기
+        tourDetailViewModel.runSearchDetailInformation(contentId)
+    }
+
+    private fun initViewModel() = with(tourDetailViewModel) {
+        getLoginStatus()
+        detailUiState.observe(this@TourModifyDetailActivity) { state ->
+            loadingDialog.setText(state.message)
+            if (state == DetailCommonUiState.error(state.message)) {
+                loadingDialog.setInvisible()
+                toast(state.message)
+                finish()
+                return@observe
+            }
+            if (state.isLoading) {
+                loadingDialog.setVisible()
+            }
+            state.detailInfo?.let { info ->
+                bindingInfo(info)
+                detailInfo = info
+                setTMap(info)
+            }
+        }
+
+        textClickEvent.observe(this@TourModifyDetailActivity) { event ->
+            when (event) {
+                is TextClickEvent.HomePageClickEvent -> {
+                    if (event.homePage == getString(R.string.no_detail_info)) {
+                        return@observe
+                    }
+                    val intent = Intent(Intent.ACTION_WEB_SEARCH).apply {
+                        putExtra("query", event.homePage)
+                    }
+                    startActivity(intent)
+                }
+
+                is TextClickEvent.PhoneNumberClickEvent -> {
+                    if (event.phoneNumber == getString(R.string.no_detail_info)) {
+                        return@observe
+                    }
+                    makePhoneCall(event.phoneNumber)
+                }
+            }
+        }
+
+        loginStatus.observe(this@TourModifyDetailActivity) { state ->
+            // 유저 정보 확인
+            currentUser = state.user
+        }
+
+        countAndRatting.observe(this@TourModifyDetailActivity) { numSet ->
+            "${if (numSet.second.isNaN()) 0.0 else numSet.second}점".also {
+                binding.evaluation.text = it
+            }
+            "${numSet.first}개의 리뷰".also { binding.tourReview.text = it }
+        }
+
+        routeMap.observe(this@TourModifyDetailActivity) { polyLine ->
+            with(binding) {
+                when (polyLine) {
+                    null -> {
+                        "${getString(R.string.find_road)} ${getString(R.string.now_loading)}".also {
+                            noticeRoute.text = it
+                        }
+                    }
+
+                    else -> {
+                        tMapView.run {
+                            addTMapPolyLine(polyLine)
+                            val info = tMapView.getDisplayTMapInfo(polyLine.linePointList)
+                            zoomLevel = info.zoom
+                            setCenterPoint(info.point.latitude, info.point.longitude, true)
+                        }
+                        noticeRoute.text = getString(R.string.find_road)
+                        // 지도까지 로딩 다 되면 다이얼로그 끄기
+                        loadingDialog.setInvisible()
+                    }
+                }
+            }
+        }
+
+        likeClickEvent.observe(this@TourModifyDetailActivity) {
+            Snackbar.make(binding.root, getString(R.string.like_place) + it, 2000).show()
+        }
+
+        likeStatus.observe(this@TourModifyDetailActivity) {
+            with(binding) {
+                btnHeart.run {
+                    isEnabled = false
+                    isSelected = it
+                    isEnabled = true
+                }
+            }
+        }
+    }
+
+    private fun doNotFrameScroll() = with(binding) {
+        container.setTouchListener(object : TMapFrameLayout.OnTouchListener {
+            override fun onTouch() {
+                nestedScrollView.requestDisallowInterceptTouchEvent(true)
+            }
+        })
+    }
+
+    private fun setTMap(info: DetailCommonEntity) {
+        tMapView = TMapView(this)
+        container.addView(tMapView)
+        tMapView.setSKTMapApiKey(BuildConfig.SK_OPEN_API_KEY)
+        setRouteOnTMap(info)
+    }
+
+    private fun setRouteOnTMap(detailInfo: DetailCommonEntity) = with(tMapView) {
+        setOnMapReadyListener {
+            setUserScrollZoomEnable(true)
+            val startMarker = TMapMarkerItem().apply {
+                id = "startMarker"
+                visible = true
+                icon = BitmapFactory.decodeResource(resources, R.drawable.icon_start_marker)
+                setTMapPoint(App.latitude, App.longitude)
+            }
+            val endMarker = TMapMarkerItem().apply {
+                id = "endMarker"
+                visible = true
+                icon = BitmapFactory.decodeResource(resources, R.drawable.icon_end_marker)
+                setTMapPoint(detailInfo.latitude.toDouble(), detailInfo.longitude.toDouble())
+            }
+            addTMapMarkerItem(startMarker)
+            addTMapMarkerItem(endMarker)
+            val startPoint = TMapPoint(App.latitude, App.longitude)
+            val endPoint =
+                TMapPoint(detailInfo.latitude.toDouble(), detailInfo.longitude.toDouble())
+            loadingDialog.setText(getString(R.string.loading_route))
+            // 경로 찾기 시작
+            tourDetailViewModel.getRouteMap(startPoint, endPoint)
+        }
+    }
+
+    private fun bindingInfo(info: DetailCommonEntity) = with(binding) {
+        imageViewMainPhoto.load(info.imageUrl)
+        tourMainTitle.text = info.title.ifEmpty { getString(R.string.no_detail_info) }
+        "${info.mainAddress}\n${info.subAddress}".also {
+            addressTour.text = it.ifEmpty { getString(R.string.no_detail_info) }
+        }
+        addressTourDetail.text = info.description.ifEmpty { getString(R.string.no_detail_info) }
+        phoneNumber.text = info.telPhoneNumber.ifEmpty { getString(R.string.no_detail_info) }
+        moveToHomepage.text = info.homePage.ifEmpty { getString(R.string.no_detail_info) }
+        addressTourDetail.post {
+            with(addressTourDetail) {
+                if (addressTourDetail.lineCount > 5) {
+                    maxLines = 5
+                    ellipsize = TextUtils.TruncateAt.END
+                } else {
+                    showMore.isVisible = false
+                }
+            }
+        }
+        showMore.setOnClickListener {
+            controlFoldTextView()
+        }
+    }
+
+    private fun controlFoldTextView() = with(binding) {
+        when (showMore.text) {
+            getString(R.string.more_description) -> {
+                addressTourDetail.maxLines = Integer.MAX_VALUE
+                addressTourDetail.ellipsize = null
+                showMore.text = getString(R.string.fold_description)
+            }
+
+            else -> {
+                addressTourDetail.maxLines = 5
+                addressTourDetail.ellipsize = TextUtils.TruncateAt.END
+                showMore.text = getString(R.string.more_description)
+            }
+        }
+    }
+
+    private fun makePhoneCall(phoneNumber: String) {
+        if (ActivityCompat.checkSelfPermission(
+                this,
+                Manifest.permission.CALL_PHONE
+            ) == PackageManager.PERMISSION_GRANTED
+        ) {
+            val intent = Intent(Intent.ACTION_CALL)
+            intent.data = Uri.parse("tel:$phoneNumber")
+            startActivity(intent)
+        } else {
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(Manifest.permission.CALL_PHONE),
+                1
+            )
+        }
+    }
+
+    private fun sharingPlace() {
+        val placeInfo = "${detailInfo.title}\n${detailInfo.telPhoneNumber}\n${detailInfo.homePage}"
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            putExtra(Intent.EXTRA_TEXT, placeInfo)
+            type = "text/plain"
+        }
+        val sharingIntent = Intent.createChooser(intent, getString(R.string.sharing_place))
+        startActivity(sharingIntent)
+    }
+}

--- a/app/src/main/java/com/nbcamp/tripgo/view/main/MainActivity.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/main/MainActivity.kt
@@ -204,14 +204,14 @@ class MainActivity : AppCompatActivity() {
                 is SetUserEvent.Success -> {
                     when (setUserEvent.currentUser) {
                         is FirebaseUser -> App.firebaseUser = setUserEvent.currentUser
-                        is Account -> App.kaKaoUser = setUserEvent.currentUser
+                        is Account -> App.kakaoUser = setUserEvent.currentUser
                     }
                     loadingDialog.run {
                         setText(setUserEvent.message)
                         setInvisible()
                     }
                     println("firebaseUserMain:" + App.firebaseUser)
-                    println("kakaoUserMain: " + App.kaKaoUser)
+                    println("kakaoUserMain: " + App.kakaoUser)
                 }
             }
 

--- a/app/src/main/java/com/nbcamp/tripgo/view/main/MainViewModel.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/main/MainViewModel.kt
@@ -10,6 +10,7 @@ import com.nbcamp.tripgo.R
 import com.nbcamp.tripgo.data.repository.model.CalendarEntity
 import com.nbcamp.tripgo.util.SingleLiveEvent
 import com.nbcamp.tripgo.view.calendar.WritingType
+import com.nbcamp.tripgo.view.calendar.uistate.CalendarScheduleUiState
 import com.nbcamp.tripgo.view.home.valuetype.ProvincePlaceEntity
 import com.nbcamp.tripgo.view.home.valuetype.TourTheme
 import com.nbcamp.tripgo.view.reviewwriting.CalendarUserModel
@@ -47,6 +48,12 @@ class MainViewModel : ViewModel() {
     private val _calendarToReviewModel: MutableLiveData<CalendarUserModel> = MutableLiveData()
     val calendarToReviewModel: LiveData<CalendarUserModel>
         get() = _calendarToReviewModel
+
+    // 일정 수정 시 수정 이벤트를 처리할 라이브 데이터
+    private val _buttonClickModifyState: MutableLiveData<CalendarScheduleUiState> =
+        MutableLiveData()
+    val buttonClickModifyState: MutableLiveData<CalendarScheduleUiState>
+        get() = _buttonClickModifyState
 
     fun runThemeTourActivity(themeId: TourTheme) {
         _event.value = ThemeClickEvent.RunTourThemeActivity(themeId)
@@ -146,5 +153,9 @@ class MainViewModel : ViewModel() {
                 _eventSetUser.postValue(SetUserEvent.Error("회원 정보 로딩 실패.."))
             }
         }
+    }
+
+    fun updateModifiedCalendarUi(state: CalendarScheduleUiState) {
+        _buttonClickModifyState.value = state
     }
 }

--- a/app/src/main/java/com/nbcamp/tripgo/view/tour/detail/TourDetailViewModel.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/tour/detail/TourDetailViewModel.kt
@@ -218,6 +218,12 @@ class TourDetailViewModel(
     }
 
     fun selectScheduleRange(dates: List<CalendarDay>, selectedDayList: List<CalendarDay>) {
+        if (dates.last().isBefore(CalendarDay.today())) {
+            // 선택한 범위가 오늘 보다 전이면, 선택을 못 하도록 막음
+            scheduleDates.clear()
+            _calendarClickEvent.value = false
+            return
+        }
         if (dates.intersect(selectedDayList.toSet()).isNotEmpty()) {
             // 겹치는 부분이 있으면 이전 저장 되어 있던 것 제거
             // 제거 안하면 확인 클릭 했을 때 isEmpty 를 통과 하여 이상 현상 발생
@@ -225,12 +231,7 @@ class TourDetailViewModel(
             _calendarClickEvent.value = true
             return
         }
-        if (dates.last().isBefore(CalendarDay.today())) {
-            // 선택한 범위가 오늘 보다 전이면, 선택을 못 하도록 막음
-            scheduleDates.clear()
-            _calendarClickEvent.value = false
-            return
-        }
+
         scheduleDates.clear()
         scheduleDates.addAll(dates)
     }

--- a/app/src/main/res/drawable/calendar_today_circle.xml
+++ b/app/src/main/res/drawable/calendar_today_circle.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
     <solid android:color="@android:color/transparent"/>
-    <stroke android:width="2dp" android:color="@color/green"/>
+    <stroke android:width="2dp" android:color="@color/deactivated"/>
 </shape>

--- a/app/src/main/res/drawable/icon_schedule_modify.xml
+++ b/app/src/main/res/drawable/icon_schedule_modify.xml
@@ -1,0 +1,5 @@
+<vector android:height="36dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="36dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M21,12V6c0,-1.1 -0.9,-2 -2,-2h-1V2h-2v2H8V2H6v2H5C3.9,4 3,4.9 3,6v14c0,1.1 0.9,2 2,2h7v-2H5V10h14v2H21zM15.64,20c0.43,1.45 1.77,2.5 3.36,2.5c1.93,0 3.5,-1.57 3.5,-3.5s-1.57,-3.5 -3.5,-3.5c-0.95,0 -1.82,0.38 -2.45,1l1.45,0V18h-4v-4h1.5l0,1.43C16.4,14.55 17.64,14 19,14c2.76,0 5,2.24 5,5s-2.24,5 -5,5c-2.42,0 -4.44,-1.72 -4.9,-4L15.64,20z"/>
+</vector>

--- a/app/src/main/res/layout/dialog_calendar.xml
+++ b/app/src/main/res/layout/dialog_calendar.xml
@@ -1,77 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
-
-    <TextView
-        android:id="@+id/title_text_view"
-        style="@style/Font.20.Bold.Black"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="20dp"
-        android:text="@string/modify_schedule"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <com.prolificinteractive.materialcalendarview.MaterialCalendarView
         android:id="@+id/add_schedule_calendar_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
-        android:layout_marginEnd="20dp"
-        android:padding="10dp"
         android:theme="@style/calendar_view_day_custom"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@id/title_text_view"
-        app:layout_constraintTop_toBottomOf="@id/title_text_view"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:mcv_allowClickDaysOutsideCurrentMonth="false"
         app:mcv_dateTextAppearance="@style/calendar_text_view_day_custom"
         app:mcv_headerTextAppearance="@style/calendar_header"
         app:mcv_selectionColor="@color/main"
-        app:mcv_selectionMode="range"
         app:mcv_showOtherDates="all"
+        app:mcv_selectionMode="range"
         app:mcv_weekDayTextAppearance="@style/calendar_text_view_week_custom" />
-
-    <TextView
-        android:id="@+id/positive_text_view"
-        style="@style/Font.16.Normal.Black"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginVertical="20dp"
-        android:layout_marginEnd="20dp"
-        android:layout_marginBottom="20dp"
-        android:background="?attr/selectableItemBackground"
-        android:clickable="true"
-        android:focusable="true"
-        android:text="@string/modify"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="@id/add_schedule_calendar_view"
-        app:layout_constraintTop_toBottomOf="@id/add_schedule_calendar_view" />
-
-    <TextView
-        android:id="@+id/negative_text_view"
-        style="@style/Font.16.Normal.Black"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="30dp"
-        android:background="?attr/selectableItemBackground"
-        android:clickable="true"
-        android:focusable="true"
-        android:text="@string/cancel"
-        app:layout_constraintBottom_toBottomOf="@id/positive_text_view"
-        app:layout_constraintEnd_toStartOf="@id/positive_text_view"
-        app:layout_constraintTop_toTopOf="@id/positive_text_view" />
 
     <ProgressBar
         android:id="@+id/calendar_progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="@id/add_schedule_calendar_view"
         app:layout_constraintEnd_toEndOf="@id/add_schedule_calendar_view"
         app:layout_constraintStart_toStartOf="@id/add_schedule_calendar_view"
-        app:layout_constraintTop_toTopOf="@id/add_schedule_calendar_view" />
+        app:layout_constraintTop_toTopOf="@id/add_schedule_calendar_view"
+        app:layout_constraintBottom_toBottomOf="@id/add_schedule_calendar_view" />
 </androidx.constraintlayout.widget.ConstraintLayout>
-
-

--- a/app/src/main/res/layout/dialog_calendar.xml
+++ b/app/src/main/res/layout/dialog_calendar.xml
@@ -1,32 +1,77 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/title_text_view"
+        style="@style/Font.20.Bold.Black"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="20dp"
+        android:text="@string/modify_schedule"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <com.prolificinteractive.materialcalendarview.MaterialCalendarView
         android:id="@+id/add_schedule_calendar_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="20dp"
+        android:padding="10dp"
         android:theme="@style/calendar_view_day_custom"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="@id/title_text_view"
+        app:layout_constraintTop_toBottomOf="@id/title_text_view"
         app:mcv_allowClickDaysOutsideCurrentMonth="false"
         app:mcv_dateTextAppearance="@style/calendar_text_view_day_custom"
         app:mcv_headerTextAppearance="@style/calendar_header"
         app:mcv_selectionColor="@color/main"
-        app:mcv_showOtherDates="all"
         app:mcv_selectionMode="range"
+        app:mcv_showOtherDates="all"
         app:mcv_weekDayTextAppearance="@style/calendar_text_view_week_custom" />
+
+    <TextView
+        android:id="@+id/positive_text_view"
+        style="@style/Font.16.Normal.Black"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="20dp"
+        android:layout_marginEnd="20dp"
+        android:layout_marginBottom="20dp"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:text="@string/modify"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/add_schedule_calendar_view"
+        app:layout_constraintTop_toBottomOf="@id/add_schedule_calendar_view" />
+
+    <TextView
+        android:id="@+id/negative_text_view"
+        style="@style/Font.16.Normal.Black"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="30dp"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:text="@string/cancel"
+        app:layout_constraintBottom_toBottomOf="@id/positive_text_view"
+        app:layout_constraintEnd_toStartOf="@id/positive_text_view"
+        app:layout_constraintTop_toTopOf="@id/positive_text_view" />
 
     <ProgressBar
         android:id="@+id/calendar_progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/add_schedule_calendar_view"
         app:layout_constraintEnd_toEndOf="@id/add_schedule_calendar_view"
         app:layout_constraintStart_toStartOf="@id/add_schedule_calendar_view"
-        app:layout_constraintTop_toTopOf="@id/add_schedule_calendar_view"
-        app:layout_constraintBottom_toBottomOf="@id/add_schedule_calendar_view" />
+        app:layout_constraintTop_toTopOf="@id/add_schedule_calendar_view" />
 </androidx.constraintlayout.widget.ConstraintLayout>
+
+

--- a/app/src/main/res/layout/dialog_calendar_modify.xml
+++ b/app/src/main/res/layout/dialog_calendar_modify.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/title_text_view"
+        style="@style/Font.20.Bold.Black"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="20dp"
+        android:text="@string/modify_schedule"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.prolificinteractive.materialcalendarview.MaterialCalendarView
+        android:id="@+id/add_schedule_calendar_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="20dp"
+        android:padding="10dp"
+        android:theme="@style/calendar_view_day_custom"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/title_text_view"
+        app:layout_constraintTop_toBottomOf="@id/title_text_view"
+        app:mcv_allowClickDaysOutsideCurrentMonth="false"
+        app:mcv_dateTextAppearance="@style/calendar_text_view_day_custom"
+        app:mcv_headerTextAppearance="@style/calendar_header"
+        app:mcv_selectionColor="@color/main"
+        app:mcv_selectionMode="range"
+        app:mcv_showOtherDates="all"
+        app:mcv_weekDayTextAppearance="@style/calendar_text_view_week_custom" />
+
+    <TextView
+        android:id="@+id/positive_text_view"
+        style="@style/Font.16.Normal.Black"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="20dp"
+        android:layout_marginEnd="20dp"
+        android:layout_marginBottom="20dp"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:text="@string/modify"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/add_schedule_calendar_view"
+        app:layout_constraintTop_toBottomOf="@id/add_schedule_calendar_view" />
+
+    <TextView
+        android:id="@+id/negative_text_view"
+        style="@style/Font.16.Normal.Black"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="30dp"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:text="@string/cancel"
+        app:layout_constraintBottom_toBottomOf="@id/positive_text_view"
+        app:layout_constraintEnd_toStartOf="@id/positive_text_view"
+        app:layout_constraintTop_toTopOf="@id/positive_text_view" />
+
+    <ProgressBar
+        android:id="@+id/calendar_progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/add_schedule_calendar_view"
+        app:layout_constraintEnd_toEndOf="@id/add_schedule_calendar_view"
+        app:layout_constraintStart_toStartOf="@id/add_schedule_calendar_view"
+        app:layout_constraintTop_toTopOf="@id/add_schedule_calendar_view" />
+</androidx.constraintlayout.widget.ConstraintLayout>
+
+

--- a/app/src/main/res/layout/fragment_calendar.xml
+++ b/app/src/main/res/layout/fragment_calendar.xml
@@ -71,6 +71,7 @@
                 android:id="@+id/calendar_schedule_recycler_view"
                 android:layout_width="0dp"
                 android:layout_height="300dp"
+                android:nestedScrollingEnabled="true"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/item_calendar_schedule_card.xml
+++ b/app/src/main/res/layout/item_calendar_schedule_card.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="10dp">
+    android:padding="10dp">
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/item_title_text_view"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -157,5 +157,11 @@
     <string name="add_schedule">일정 추가</string>
     <string name="not_login_then_not_submit_like">로그인이 되어 있지 않아 찜 목록에 추가할 수 없습니다.</string>
     <string name="login_en">LOGIN</string>
+    <string name="cancel">취소</string>
+    <string name="modify">수정</string>
+    <string name="modify_schedule">스케줄 수정</string>
+    <string name="now_doing_schedule_cant_modify">현재 진행 중인 일정은 수정할 수 없습니다.</string>
+    <string name="past_schedule_not_modify">이미 지난 일정은 수정할 수 없습니다.</string>
+    <string name="sharing_place">공유하기</string>
 
 </resources>


### PR DESCRIPTION
일정 삭제 및 수정 기능 구현을 구현하였습니다.
구현하는데 있어 기능 flow를 바꿀 필요성이 있어 개편하였습니다.

캘린더 프래그먼트 동작 flow 재정립

- 리사이클러뷰
    - 일정이 지나거나 오늘이 해당 일정일 경우
        - 리뷰가 작성 안 된 것 → 클릭 시 리뷰 작성 다이얼로그 생성, 롱 클릭시 일정 삭제 다이얼로그 생성
        - 리뷰 작성이 된 것 → 클릭 시 리뷰 수정 다이얼로그 생성, 롱 클릭 시 토스트 메세지(일정 삭제 불가)
        - 왼쪽 스와이프 - 상세페이지로 이동 - 수정 버튼은 비활성화
    - 일정이 지나지 않은 것
        - 롱 클릭 → 일정 삭제 할 지 다이얼로그 생성
        - 왼쪽 스와이프 - 상세페이지로 이동 - 수정 버튼 활성화 → 일정이 지나지 않은 것만 일정 수정 가능
- 캘린더
    - 일정이 지나거나 오늘이 해당 일정일 경우
        - 리뷰 작성이 안 된 것 → 롱 클릭시 리뷰 작성 다이얼로그 생성
        - 리뷰 작성이 된 것 → 롱 클릭 시 리뷰 수정 다이얼로그 생성
    - 일정이 지나지 않은 것
        - 롱 클릭 → 리뷰 작성이 불가하다는 토스트메세지 출력

close #83 