### PR TITLE
[FIX]: 전국 관광지 리스트 텍스트뷰 출력 오류

### DIFF
--- a/app/src/main/java/com/nbcamp/tripgo/view/home/adapter/ProvincePlaceListAdapter.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/home/adapter/ProvincePlaceListAdapter.kt
@@ -47,7 +47,7 @@ class ProvincePlaceListAdapter(
                 onClickItem(model)
             }
             itemTitleTextView.text = model.name
-            "$str" + context.getString(R.string.many_tour_place).also {
+            ("$str" + context.getString(R.string.many_tour_place)).also {
                 itemDescriptionTextView.text = it
             }
             // 이미지가 없을 떄 텍스트 색 바꾸기


### PR DESCRIPTION
## 구현 사항
- 전국 관광지 리스트의 n곳 이상의 관광지 출력 부분에서 n이 표기 되지 않던 현상을 수정하였습니다.

## 주요 변동 파일
- ProvincePlaceListAdapter.kt
  - 숫자와 문자열을 하나의 문자열로 묶어줌
---
close #139 