### PR TITLE
[FIX] 버그 및 부족한 기능부분 1차 수정

### DIFF
--- a/app/src/main/java/com/nbcamp/tripgo/view/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/mypage/MyPageFragment.kt
@@ -7,10 +7,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
+import coil.load
+import coil.transform.CircleCropTransformation
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FirebaseFirestore
@@ -18,7 +21,9 @@ import com.nbcamp.tripgo.R
 import com.nbcamp.tripgo.view.App
 import com.nbcamp.tripgo.view.login.LogInActivity
 import com.nbcamp.tripgo.view.mypage.favorite.FavoriteFragment
+import com.nbcamp.tripgo.view.mypage.favorite.MypageAppInpo
 import com.nbcamp.tripgo.view.review.mypage.ReviewFragment
+import org.w3c.dom.Text
 
 class MyPageFragment : Fragment() {
 
@@ -39,6 +44,7 @@ class MyPageFragment : Fragment() {
         val logoutButton = view.findViewById<Button>(R.id.mypage_logout_button)
         val userLayout = view.findViewById<LinearLayout>(R.id.mypage_userlayout)
         val openSourceLicenseTextView = view.findViewById<TextView>(R.id.mypage_opensource_textview)
+        val appInpo = view.findViewById<TextView>(R.id.mypage_appinpo_textview)
 
 
         reviewLayout.setOnClickListener { navigateToFragment(ReviewFragment()) }
@@ -46,18 +52,60 @@ class MyPageFragment : Fragment() {
         logoutButton.setOnClickListener { logout() }
         userLayout.setOnClickListener { showUserDialog() }
         openSourceLicenseTextView.setOnClickListener { runOpenSourceDialog() }
+        appInpo.setOnClickListener {
+            val appinfodialog = MypageAppInpo()
+            appinfodialog.show(parentFragmentManager, "app_info_dialog")
+        }
+
+
+        return view
+    }
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
         // Firebase 정보 가져오고 UI 업데이트
         fetchFirebaseDataAndUIUpdate(view)
 
-        return view
+        imageupdate()
+
+        changetextbutton()
     }
+
+    private fun imageupdate() {
+        val firestore = FirebaseFirestore.getInstance()
+        val auth = FirebaseAuth.getInstance()
+        val user = auth.currentUser
+        val userEmail = user?.email
+        val userRef = firestore.collection("users").document(userEmail.toString())
+
+        userRef.get().addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+                val document = task.result
+                if (document != null && document.exists()) {
+                    val profileImageUrl = document.getString("profileImageUrl")
+                    if (!profileImageUrl.isNullOrEmpty()) {
+
+                        val imageView = view?.findViewById<ImageView>(R.id.mypage_usericon)
+
+                        Log.d("MYpageurl", profileImageUrl)
+
+                        imageView?.load(profileImageUrl){
+                            transformations(CircleCropTransformation())
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 
     private fun fetchFirebaseDataAndUIUpdate(view: View) {
         val auth = FirebaseAuth.getInstance()
         val user = auth.currentUser
         val userEmail = user?.email
         val firestoredb = FirebaseFirestore.getInstance()
+
+        Log.d("mypageemail" ,userEmail.toString())
 
         val kakaouser = App.kakaoUser?.email
 
@@ -72,23 +120,39 @@ class MyPageFragment : Fragment() {
             }
         }
 
-
         dbinpo?.get()
-            ?.addOnSuccessListener { documentSnapshot ->
-                if (documentSnapshot.exists()) {
-                    val userdata = documentSnapshot.data
+            ?.addOnSuccessListener { document ->
+                if (document.exists()) {
+                    val userdata = document.data
                     val email = userdata?.get("email") as? String
+                    Log.d("MYPAGEDBINPO",email.toString())
                     val nickname = userdata?.get("nickname") as? String
+                    Log.d("MYPAGEDBINPO",nickname.toString())
 
                     nicknameText.text = nickname?.let { "   $it 님" } ?: ""
                     emailText.text = email?.let { "   $it" } ?: ""
                 } else {
-                    Log.d(TAG, "document를 찾을 수 없습니다.")
+                    Log.d("Mypagefail", "document를 찾을 수 없습니다.")
                 }
             }
             ?.addOnFailureListener { e ->
                 Log.d(TAG, "실 패 ! $e")
             }
+    }
+
+    private fun changetextbutton(){
+        val auth = FirebaseAuth.getInstance()
+        val user = auth.currentUser
+        val logoutButton = view?.findViewById<Button>(R.id.mypage_logout_button)
+        val kakaouser = App.kakaoUser?.email
+        if(user != null || kakaouser != null ){
+            logoutButton?.text = "로그아웃"
+        }
+
+        else{
+            logoutButton?.text = "로그인"
+        }
+
     }
 
     private fun navigateToFragment(fragment: Fragment) {
@@ -99,6 +163,7 @@ class MyPageFragment : Fragment() {
     }
 
     private fun logout() {
+        FirebaseAuth.getInstance().signOut()
         App.firebaseUser = null
         App.kakaoUser = null
         val intent = Intent(context, LogInActivity::class.java)

--- a/app/src/main/java/com/nbcamp/tripgo/view/mypage/ProfileModifyFragment.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/mypage/ProfileModifyFragment.kt
@@ -1,20 +1,37 @@
 package com.nbcamp.tripgo.view.mypage
 
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
+import android.provider.MediaStore
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.widget.AppCompatEditText
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import coil.load
+import coil.transform.CircleCropTransformation
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.storage.FirebaseStorage
 import com.nbcamp.tripgo.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+import retrofit2.http.Url
+import java.util.UUID
 
 class ProfileModifyFragment : Fragment() {
     private lateinit var refreshNickText: AppCompatEditText
+    private var selectedImageUri: Uri? = null  // 이미지 URI를 저장할 변수
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -25,19 +42,30 @@ class ProfileModifyFragment : Fragment() {
         refreshNickText = view.findViewById(R.id.profile_edit_username)
 
         val saveButton = view.findViewById<AppCompatImageView>(R.id.profile_edit_complete_textivew)
-        saveButton.setOnClickListener { updateNickname() }
+        saveButton.setOnClickListener { updateProfile() }
 
         val backButton = view.findViewById<AppCompatImageView>(R.id.profile_back_imagebutton)
         backButton.setOnClickListener{ navigateToMyPageFragment() }
 
+        val imageButton = view?.findViewById<ImageView>(R.id.profile_edit_user_imageview)
+        imageButton?.setOnClickListener { changeimage() }
+
+        imageupdate()
 
         return view
     }
 
-
-
-    private fun updateNickname() {
+    private fun updateProfile() {
         val editNickname = refreshNickText.text.toString()
+        if (editNickname.isEmpty()) {
+            showToast("닉네임을 입력하세요.")
+            return
+        }
+        if (selectedImageUri == null) {
+            showToast("프로필 이미지를 선택하세요.")
+            return
+        }
+
         val firestore = FirebaseFirestore.getInstance()
         val userId = userEmail()
         val userRef = firestore.collection("users").document(userId)
@@ -52,11 +80,19 @@ class ProfileModifyFragment : Fragment() {
                         if (!nicknameExists) {
                             val data = hashMapOf("nickname" to editNickname)
 
-                            userRef.update(data as Map<String, Any>).addOnSuccessListener {
-                                showToast("닉네임이 업데이트되었습니다.")
-                                navigateToMyPageFragment()
-                            }.addOnFailureListener {
-                                showToast("닉네임 업데이트에 실패했습니다.")
+                            // 이미지를 Firebase Storage에 업로드하고 업로드가 완료되면 Firestore에 이미지 URL을 업데이트합니다.
+                            uploadImageToFirebaseStorage(selectedImageUri) { imageUrl ->
+                                if (imageUrl.isNotEmpty()) {
+                                    data["profileImageUrl"] = imageUrl  // 이미지 URL을 데이터에 추가
+                                    userRef.update(data as Map<String, Any>).addOnSuccessListener {
+                                        showToast("프로필이 업데이트되었습니다.")
+                                        navigateToMyPageFragment()
+                                    }.addOnFailureListener {
+                                        showToast("프로필 업데이트에 실패했습니다.")
+                                    }
+                                } else {
+                                    showToast("프로필 이미지 업데이트에 실패했습니다.")
+                                }
                             }
                         } else {
                             showToast("닉네임이 이미 사용중입니다.")
@@ -101,5 +137,71 @@ class ProfileModifyFragment : Fragment() {
             .replace(R.id.main_fragment_container, MyPageFragment())
             .addToBackStack(null)
             .commit()
+    }
+
+    private fun changeimage() {
+        val galleryIntent = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
+        startActivityForResult(galleryIntent, GALLERY_REQUEST_CODE)
+    }
+
+    private fun uploadImageToFirebaseStorage(imageUri: Uri?, callback: (String) -> Unit) {
+        val userId = userEmail()
+        val storagePath = "users/$userId/profileImage/${UUID.randomUUID()}.jpg"
+        val storageReference = FirebaseStorage.getInstance().getReference(storagePath)
+
+        val uploadTask = storageReference.putFile(imageUri!!)
+
+        uploadTask.addOnSuccessListener { taskSnapshot ->
+            storageReference.downloadUrl.addOnSuccessListener { uri ->
+                val imageUrl = uri.toString()
+                callback(imageUrl)
+            }
+        }.addOnFailureListener { exception ->
+            Log.e("ProfileModifyFragment", "Storage에 업로드 오류 : $exception")
+            callback("")
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == GALLERY_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
+            selectedImageUri = data?.data
+            val imageView = view?.findViewById<ImageView>(R.id.profile_edit_user_imageview)
+            imageView?.setImageURI(selectedImageUri)
+            Log.d("imageurl", selectedImageUri.toString())
+        }
+    }
+
+    private fun imageupdate() {
+        val firestore = FirebaseFirestore.getInstance()
+        val auth = FirebaseAuth.getInstance()
+        val user = auth.currentUser
+        val userEmail = user?.email
+        val userRef = firestore.collection("users").document(userEmail.toString())
+
+        userRef.get().addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+                val document = task.result
+                if (document != null && document.exists()) {
+                    val profileImageUrl = document.getString("profileImageUrl")
+                    if (!profileImageUrl.isNullOrEmpty()) {
+
+                        val modifyimageview = view?.findViewById<ImageView>(R.id.profile_edit_user_imageview)
+
+                        Log.d("MYpageurl", profileImageUrl)
+
+                        modifyimageview?.load(profileImageUrl){
+                            transformations(CircleCropTransformation())
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+
+    companion object{
+        private const val GALLERY_REQUEST_CODE = 123
     }
 }

--- a/app/src/main/java/com/nbcamp/tripgo/view/mypage/favorite/MypageAppInpo.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/mypage/favorite/MypageAppInpo.kt
@@ -1,0 +1,21 @@
+package com.nbcamp.tripgo.view.mypage.favorite
+
+import android.app.Dialog
+import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import com.nbcamp.tripgo.R
+
+class MypageAppInpo : DialogFragment() {
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val inflater = requireActivity().layoutInflater
+        val dialogView = inflater.inflate(R.layout.dialog_app_inpo, null)
+
+        return AlertDialog.Builder(requireContext())
+            .setView(dialogView)
+            .setPositiveButton("닫기") { dialog, _ ->
+                dialog.dismiss()
+            }
+            .create()
+    }
+}

--- a/app/src/main/res/layout/dialog_app_inpo.xml
+++ b/app/src/main/res/layout/dialog_app_inpo.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <ImageView
+        android:layout_width="100dp"
+        android:layout_height="100dp"
+        android:src="@drawable/icon_main_logo"
+    android:layout_gravity="center_horizontal"
+    android:layout_marginBottom="16dp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="고민말GO 트립GO"
+    android:textSize="24sp"
+    android:layout_gravity="center_horizontal"
+    android:layout_marginBottom="8dp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="버전: 1.0"
+    android:textSize="16sp"
+    android:layout_gravity="center_horizontal"
+    android:layout_marginBottom="16dp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="개발자: 스파르타 9 팀"
+    android:textSize="16sp"
+    android:layout_gravity="center_horizontal"
+    android:layout_marginBottom="16dp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="이메일 입력하기"
+    android:textSize="16sp"
+    android:layout_gravity="center_horizontal" />
+</LinearLayout>


### PR DESCRIPTION
수정한부분
- 프로필 수정 시 이미지 선택해서 업로드하는 로직이 존재하지 않아 유저의 프로필이미지 url을 업데이트 할 수 없음
- > 이미지 마이페이지, 마이페이지 dialog, profilemodify에서도 image불러오기 및 image 수정까지 가능

- 로그인이 안 된 상태에서 프로필을 눌렀을 시, 프로필 다이얼로그가 뜨고, 프로필 수정까지 진입을 할 수 있는 현상
- > 로그인 안된상태일때 클릭시 toast문구출력 및 넘어가지지않음 ( 다이얼로그까진 작동)

-현재는 마이 페이지에서 로그아웃 버튼을 누르면 로그인 페이지로 넘어가는데, 사용자 입장에선 어색한 부분이 있음.
- > 로그인상태에 따라 text의 구분을 다르게 설정해뒀음

-마이페이지의 하단 정보 창 4가지를 구현을 할 지? (자주 묻는 질문, 앱정보 등)
- > 앱정보는 완료하였으나 자주묻는 질문에대해선 뭘 정하지않아서 구상만 완료

-> 추가적으로 sha-1키 입력후 googleLogin 확인해봐야됨.
->소셜로그인 시 firebase store에  사용자의 정보를 저장하는데, 사용자의 프로필이미지를 null로 저장함 이부분도 논의가필요.
 