### PR TITLE
[FIX] 관광지 클릭 시 추가 데이터 거리 순으로 정렬 + 중복 처리

### DIFF
--- a/app/src/main/java/com/nbcamp/tripgo/view/attraction/AttractionsActivity.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/attraction/AttractionsActivity.kt
@@ -35,7 +35,7 @@ import com.nbcamp.tripgo.view.tour.detail.TourDetailActivity
 
 class AttractionsActivity : AppCompatActivity() {
     companion object {
-        const val MAX_ROWS = 20
+        const val MAX_ROWS = 100
         const val REQUEST_CHECK_SETTINGS = 1001
         const val LOCATION_PERMISSION_REQUEST_CODE = 1234
     } // numOfRows
@@ -108,6 +108,8 @@ class AttractionsActivity : AppCompatActivity() {
             attractionsAdapter.attractionDate(binding.attractionRecyclerview)
             updateButtonColors(isDistanceSelected = false)
         }
+
+        updateButtonColors(isDistanceSelected = true)
 
         // 위치 권한 체크 후 처리
         if (ContextCompat.checkSelfPermission(
@@ -186,12 +188,15 @@ class AttractionsActivity : AppCompatActivity() {
                     )
                 }
                 if (response.isSuccessful && response.body() != null) {
-                    val area = response.body()?.response?.body?.items?.item
-                    if (area != null) {
-                        if (area.size < MAX_ROWS) {
+                    val newAreas = response.body()?.response?.body?.items?.item.orEmpty()
+                    val currentIds = attractionsAdapter.currentList.map { it.contentid }.toSet()
+                    val nonDuplicateAreas = newAreas.filter { it.contentid !in currentIds }
+
+                    if (nonDuplicateAreas.isNotEmpty()) {
+                        if (nonDuplicateAreas.size < MAX_ROWS) {
                             isLastPage = true
                         }
-                        attractionsAdapter.submitList(area)
+                        attractionsAdapter.updateListWithDistanceSorting(nonDuplicateAreas)
                     }
                 } else {
                     showError(getString(R.string.tour_error))

--- a/app/src/main/java/com/nbcamp/tripgo/view/attraction/AttractionsAdapter.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/attraction/AttractionsAdapter.kt
@@ -8,6 +8,7 @@ import androidx.recyclerview.widget.RecyclerView
 import coil.load
 import com.nbcamp.tripgo.R
 import com.nbcamp.tripgo.data.model.area.AreaItem
+import com.nbcamp.tripgo.data.model.keywords.KeywordItem
 import com.nbcamp.tripgo.databinding.AttractionRecyclerviewItemBinding
 
 class AttractionsAdapter(private val onClickItem: (AreaItem) -> Unit) :
@@ -22,7 +23,24 @@ class AttractionsAdapter(private val onClickItem: (AreaItem) -> Unit) :
         notifyDataSetChanged()
     } // 위치 정보 변경 후 , RecyclerView 갱신
 
+    fun calculateDistance(item: AreaItem): Double {
+        return calculateDistanceTo(
+            item.mapx.toDouble(),
+            item.mapy.toDouble(),
+            userLat,
+            userLon
+        )
+    }
 
+    fun updateListWithDistanceSorting(newItems: List<AreaItem>) {
+        val totalList = ArrayList(currentList).apply {
+            addAll(newItems)
+        }.distinctBy { it.contentid }
+        val sortedByDistance = totalList.sortedBy { item ->
+            calculateDistance(item)
+        }
+        submitList(sortedByDistance)
+    }
 
     private fun calculateDistanceTo(
         mapx: Double,
@@ -31,17 +49,14 @@ class AttractionsAdapter(private val onClickItem: (AreaItem) -> Unit) :
         userLon: Double
     ): Double {
         val R = 6371.0
-
         val dLat = Math.toRadians(mapy - userLat)
         val dLon = Math.toRadians(mapx - userLon)
-
         val a =
             Math.sin(dLat / 2) * Math.sin(dLat / 2) +
                     Math.cos(Math.toRadians(userLat)) *
                     Math.cos(Math.toRadians(mapy)) *
                     Math.sin(dLon / 2) * Math.sin(dLon / 2)
         val c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
-
         return R * c
     } // 사용자 위치와 주어진 좌표 간의 거리를 계산 하는 함수
 

--- a/app/src/main/java/com/nbcamp/tripgo/view/tour/adapter/TourNearAdapter.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/tour/adapter/TourNearAdapter.kt
@@ -1,5 +1,6 @@
 package com.nbcamp.tripgo.view.tour.adapter
 
+import android.location.Location
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
@@ -16,6 +17,20 @@ class TourNearAdapter(
 
     private var userLat = 0.0 // 사용자 위도
     private var userLon = 0.0 // 사용자 경도
+
+    fun addAndSortByDistance(newItems: List<NearbyItem>, userLat: Double, userLon: Double) {
+        val allItems = currentList + newItems
+        val uniqueItems = allItems.distinctBy { it.contentid }
+        val sortedItems = uniqueItems.sortedBy {
+            calculateDistanceTo(
+                it.mapx.toDouble(),
+                it.mapy.toDouble(),
+                userLat,
+                userLon
+            )
+        }
+        submitList(sortedItems)
+    }
 
     fun setUserLocation(lat: Double, lon: Double) {
         userLat = lat

--- a/app/src/main/java/com/nbcamp/tripgo/view/tour/adapter/TourSearchAdapter.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/tour/adapter/TourSearchAdapter.kt
@@ -10,6 +10,9 @@ import com.nbcamp.tripgo.R
 import com.nbcamp.tripgo.data.model.keywords.Items
 import com.nbcamp.tripgo.data.model.keywords.KeywordItem
 import com.nbcamp.tripgo.databinding.TourRecyclerviewItemBinding
+import java.text.ParseException
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 class TourSearchAdapter(
     private val onClickItem: (KeywordItem) -> Unit // 아이템 클릭시 실행할 콜백 함수
@@ -17,6 +20,15 @@ class TourSearchAdapter(
 
     private var userLat = 0.0 // 사용자 위도
     private var userLon = 0.0 // 사용자 경도
+
+    fun calculateDistance(item: KeywordItem): Double {
+        return calculateDistanceTo(
+            item.mapx.toDouble(),
+            item.mapy.toDouble(),
+            userLat,
+            userLon
+        )
+    }
 
     fun setUserLocation(lat: Double, lon: Double) {
         userLat = lat


### PR DESCRIPTION
## 구현 사항

- 여행지 테마 클릭 시 첫 화면 거리 순 으로 정렬
- 전국 관광지 클릭시 첫 화면 거리 순 으로 정렬
- 인기 있는 페스티벌 클릭 시 첫 화면 날짜 순으로 정렬
- 각각 여행지 무한 스크롤링 시 추가 데이터도 거리 순 / 날짜 순 으로 정렬 + 중복 여행지 처리

## 주요 변동 파일
- TourActivity
   - getThemeSearch()
   - getThemeNear()
   - getFestivalSearch()
- AttractionsActivity
   - getArea() 

close #166 