### PR TITLE
[FEAT] 회원 탈퇴 로직 추가

### DIFF
--- a/app/src/main/java/com/nbcamp/tripgo/data/repository/ReviewWritingRepositoryImpl.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/data/repository/ReviewWritingRepositoryImpl.kt
@@ -67,6 +67,11 @@ class ReviewWritingRepositoryImpl : ReviewWritingRepository {
     ) {
         // 데이터 무결성을 위해 트랜잭션 사용
         fireStore.runTransaction { transaction ->
+            // 하위 문서를 위한 더미데이터
+            fireStore.collection("reviews")
+                .document(userInfo)
+                .set(mapOf("dummy" to ""))
+
             val userReference =
                 fireStore.collection("users").document(userInfo)
             val reviewReference =

--- a/app/src/main/java/com/nbcamp/tripgo/data/repository/TourDetailRepositoryImpl.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/data/repository/TourDetailRepositoryImpl.kt
@@ -58,6 +58,11 @@ class TourDetailRepositoryImpl(
         }
 
         fireStore.runTransaction { transaction ->
+            // 하위 문서를 위한 더미데이터
+            fireStore.collection("reviews")
+                .document(userInfo)
+                .set(mapOf("dummy" to ""))
+
             val calendarScheduleReference =
                 fireStore.collection("calendar")
                     .document(email)
@@ -110,6 +115,11 @@ class TourDetailRepositoryImpl(
     ) {
         getUserInfo()
         fireStore.runTransaction { transaction ->
+            // 하위 문서를 위한 더미데이터
+            fireStore.collection("liked")
+                .document(userInfo)
+                .set(mapOf("dummy" to ""))
+
             val likedReference = fireStore.collection("liked")
                 .document(userInfo)
                 .collection("like")

--- a/app/src/main/java/com/nbcamp/tripgo/view/login/LogInActivity.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/login/LogInActivity.kt
@@ -62,7 +62,7 @@ class LogInActivity : AppCompatActivity() {
 
         loadingDialog = LoadingDialog(this)
 
-        loadingDialog.hide() // 로딩 화면 숨기기
+        loadingDialog.setInvisible() // 로딩 화면 숨기기
 
         initializeViews()
         setupListeners()
@@ -133,6 +133,7 @@ class LogInActivity : AppCompatActivity() {
                 if (authResult.isSuccessful) {
                     val user = auth.currentUser
                     if (user != null && user.isEmailVerified) {
+                        hideLoadingDialog()
                         val intent = Intent(this, MainActivity::class.java)
                         startActivity(intent)
                         finish()

--- a/app/src/main/java/com/nbcamp/tripgo/view/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/mypage/MyPageFragment.kt
@@ -3,7 +3,6 @@ package com.nbcamp.tripgo.view.mypage
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -15,7 +14,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import coil.load
 import coil.transform.CircleCropTransformation
-import com.google.android.material.snackbar.Snackbar
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.nbcamp.tripgo.R
@@ -110,12 +108,10 @@ class MyPageFragment : Fragment() {
         viewModel.email.observe(viewLifecycleOwner) { email ->
             emailText.text = "   $email"
             checkAndDismissLoadingDialog()
-            Log.d("MYpage값확인중", "$email")
         }
         viewModel.nickname.observe(viewLifecycleOwner) { nickname ->
             nicknameText.text = "   $nickname 님"
             checkAndDismissLoadingDialog()
-            Log.d("MYpage값확인중", "$nickname")
         }
         viewModel.fetchDataFromFirebase()
         imageupdate()
@@ -124,7 +120,7 @@ class MyPageFragment : Fragment() {
     private fun checkAndDismissLoadingDialog() {
         // email과 nickname이 모두 채워졌는지 확인
         if (emailText.text.isNotBlank() && nicknameText.text.isNotBlank()) {
-            loadingDialog.hide()
+            loadingDialog.setInvisible()
         }
     }
 
@@ -162,7 +158,7 @@ class MyPageFragment : Fragment() {
         }
         CoroutineScope(Dispatchers.Main).launch {
             delay(5500) //
-            loadingDialog.hide() // 로딩 화면 숨기기
+            loadingDialog.setInvisible() // 로딩 화면 숨기기
         }
     }
 

--- a/app/src/main/java/com/nbcamp/tripgo/view/mypage/ProfileModifyViewModel.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/mypage/ProfileModifyViewModel.kt
@@ -1,0 +1,92 @@
+package com.nbcamp.tripgo.view.mypage
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.storage.FirebaseStorage
+import com.kakao.sdk.user.UserApiClient
+import com.nbcamp.tripgo.view.App
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+
+class ProfileModifyViewModel : ViewModel() {
+    private val auth = FirebaseAuth.getInstance()
+    private val storage = FirebaseStorage.getInstance()
+    private val firebaseStore = FirebaseFirestore.getInstance()
+
+    private val _deleteStatus: MutableLiveData<UserDeleteStatus> = MutableLiveData()
+    val deleteStatus: LiveData<UserDeleteStatus>
+        get() = _deleteStatus
+
+    fun withDrawlUser() {
+        _deleteStatus.value = UserDeleteStatus.Initialize
+        runCatching {
+            if (App.kakaoUser == null) {
+                // auth 회원 탈퇴
+                auth.currentUser?.delete()
+                    ?.addOnCompleteListener {
+                        println("result: " + it.result)
+                        if (it.isSuccessful) {
+                            println("success: " + it.result)
+                            App.firebaseUser?.email?.let { email ->
+                                viewModelScope.launch(Dispatchers.IO) {
+                                    deleteUserInfo(email)
+                                }
+                            }
+                        } else {
+                            println("fail: "+it.result)
+                            // 탈퇴 실패
+                            _deleteStatus.postValue(UserDeleteStatus.Error("삭제 실패"))
+                        }
+                    }
+            } else {
+                // 카카오 회원 탈퇴
+                UserApiClient.instance.unlink { error ->
+                    if(error != null) {
+                        App.kakaoUser?.email?.let { email ->
+                            viewModelScope.launch(Dispatchers.IO) {
+                                deleteUserInfo(email)
+                            }
+                        }
+                    } else {
+                        // 탈퇴 실패
+                        _deleteStatus.postValue(UserDeleteStatus.Error("삭제 실패"))
+                    }
+                }
+            }
+        }.onFailure {
+            _deleteStatus.postValue(UserDeleteStatus.Error("삭제 실패"))
+        }
+    }
+
+    private suspend fun deleteUserInfo(email: String) {
+        println("delete: $email")
+        firebaseStore.runTransaction {
+            firebaseStore.collection("users").document(email)
+                .delete()
+            _deleteStatus.postValue(UserDeleteStatus.Success("유저 정보 삭제 완료"))
+            firebaseStore.collection("reviews").document(email)
+                .delete()
+            _deleteStatus.postValue(UserDeleteStatus.Success("리뷰 삭제 완료"))
+            firebaseStore.collection("calendar").document(email)
+                .delete()
+            _deleteStatus.postValue(UserDeleteStatus.Success("일정 삭제 완료"))
+            firebaseStore.collection("liked").document(email)
+                .delete()
+            _deleteStatus.postValue(UserDeleteStatus.Success("좋아요 정보 삭제 완료"))
+
+            storage.reference.child("reviews").child(email).delete()
+            storage.reference.child("users").child(email).delete()
+        }.await()
+
+        App.kakaoUser = null
+        App.firebaseUser = null
+
+        _deleteStatus.postValue(UserDeleteStatus.Success("모든 정보 삭제 완료"))
+    }
+}
+

--- a/app/src/main/java/com/nbcamp/tripgo/view/mypage/UserDeleteStatus.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/mypage/UserDeleteStatus.kt
@@ -1,0 +1,13 @@
+package com.nbcamp.tripgo.view.mypage
+
+sealed interface UserDeleteStatus{
+    object Initialize: UserDeleteStatus
+
+    data class Success(
+        val message: String
+    ): UserDeleteStatus
+
+    data class Error(
+        val message: String
+    ): UserDeleteStatus
+}


### PR DESCRIPTION
## 구현 사항
- 회원 탈퇴 로직을 추가하였습니다.
- 다이얼로그 제거 로직을 수정하였습니다.

## 주요 변동 파일
- ProfileModifyViewModel.kt
  - 현재 로그인한 사용자를 확인 후, 사용자에 맞는 모든 정보(리뷰, 좋아요, 일정, 사용자 정보)를 삭제
- LoginActivity.kt, ProfileModifyFragment.kt
  - loadingDialog 제거 로직 변경
---
close #170 