### PR TITLE
[FIX] 홈 로딩 속도 개선 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,7 @@
             android:value="@string/KAKAO_API_KEY"/>
         <activity
             android:name=".view.SplashActivity"
+            android:noHistory="true"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/nbcamp/tripgo/data/repository/model/FestivalEntity.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/data/repository/model/FestivalEntity.kt
@@ -17,4 +17,4 @@ data class FestivalEntity(
     val imageUrl: String,
     // 시도 주소
     val address: String
-): Parcelable
+) : Parcelable

--- a/app/src/main/java/com/nbcamp/tripgo/data/repository/model/FestivalEntity.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/data/repository/model/FestivalEntity.kt
@@ -1,5 +1,9 @@
 package com.nbcamp.tripgo.data.repository.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class FestivalEntity(
     // 컨텐츠 고유번호
     val contentId: String,
@@ -13,4 +17,4 @@ data class FestivalEntity(
     val imageUrl: String,
     // 시도 주소
     val address: String
-)
+): Parcelable

--- a/app/src/main/java/com/nbcamp/tripgo/view/SplashActivity.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/SplashActivity.kt
@@ -47,24 +47,22 @@ class SplashActivity : AppCompatActivity() {
 
     private fun initViewModel() = with(homeViewModel) {
         festivalUiState.observe(this@SplashActivity) {
-            if(it.list.isNullOrEmpty().not())
+            if (it.list.isNullOrEmpty().not())
                 homeFestivalUiState = it
             runHomeFragment()
-
         }
         provincePlaceUiState.observe(this@SplashActivity) {
-            if(it.list.isNullOrEmpty().not())
+            if (it.list.isNullOrEmpty().not())
                 homeProvinceUiState = it
             runHomeFragment()
         }
     }
 
     private fun runHomeFragment() {
-        if(::homeFestivalUiState.isInitialized && ::homeProvinceUiState.isInitialized) {
+        if (::homeFestivalUiState.isInitialized && ::homeProvinceUiState.isInitialized) {
             val intent = Intent(this, MainActivity::class.java).apply {
                 putExtra(FESTIVAL_EXTRA_KEY, homeFestivalUiState)
                 putExtra(PROVINCE_EXTRA_KEY, homeProvinceUiState)
-
             }
             startActivity(intent)
             overridePendingTransition(R.anim.slide_up_enter, R.anim.slide_down_exit)

--- a/app/src/main/java/com/nbcamp/tripgo/view/SplashActivity.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/SplashActivity.kt
@@ -3,18 +3,27 @@ package com.nbcamp.tripgo.view
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import com.airbnb.lottie.LottieDrawable
 import com.nbcamp.tripgo.R
 import com.nbcamp.tripgo.databinding.ActivitySplashBinding
+import com.nbcamp.tripgo.view.home.HomeViewModel
+import com.nbcamp.tripgo.view.home.HomeViewModelFactory
+import com.nbcamp.tripgo.view.home.uistate.HomeFestivalUiState
+import com.nbcamp.tripgo.view.home.uistate.HomeProvincePlaceUiState
 import com.nbcamp.tripgo.view.main.MainActivity
+import com.nbcamp.tripgo.view.main.MainActivity.Companion.FESTIVAL_EXTRA_KEY
+import com.nbcamp.tripgo.view.main.MainActivity.Companion.PROVINCE_EXTRA_KEY
 
 @SuppressLint("CustomSplashScreen")
 class SplashActivity : AppCompatActivity() {
     private val binding by lazy {
         ActivitySplashBinding.inflate(layoutInflater)
     }
+    private val homeViewModel: HomeViewModel by viewModels { HomeViewModelFactory() }
+    private lateinit var homeFestivalUiState: HomeFestivalUiState
+    private lateinit var homeProvinceUiState: HomeProvincePlaceUiState
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -24,12 +33,41 @@ class SplashActivity : AppCompatActivity() {
             setAnimation("lottie_5.json")
             speed = 4f
             playAnimation()
+            repeatCount = LottieDrawable.INFINITE
         }
 
-        Handler(Looper.getMainLooper()).postDelayed({
-            val intent = Intent(this, MainActivity::class.java)
+        initViewModel()
+        fetchHomeData()
+    }
+
+    private fun fetchHomeData() = with(homeViewModel) {
+        fetchViewPagerData()
+        getProvincePlace()
+    }
+
+    private fun initViewModel() = with(homeViewModel) {
+        festivalUiState.observe(this@SplashActivity) {
+            if(it.list.isNullOrEmpty().not())
+                homeFestivalUiState = it
+            runHomeFragment()
+
+        }
+        provincePlaceUiState.observe(this@SplashActivity) {
+            if(it.list.isNullOrEmpty().not())
+                homeProvinceUiState = it
+            runHomeFragment()
+        }
+    }
+
+    private fun runHomeFragment() {
+        if(::homeFestivalUiState.isInitialized && ::homeProvinceUiState.isInitialized) {
+            val intent = Intent(this, MainActivity::class.java).apply {
+                putExtra(FESTIVAL_EXTRA_KEY, homeFestivalUiState)
+                putExtra(PROVINCE_EXTRA_KEY, homeProvinceUiState)
+
+            }
             startActivity(intent)
             overridePendingTransition(R.anim.slide_up_enter, R.anim.slide_down_exit)
-        }, 2500)
+        }
     }
 }

--- a/app/src/main/java/com/nbcamp/tripgo/view/SplashActivity.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/SplashActivity.kt
@@ -30,7 +30,6 @@ class SplashActivity : AppCompatActivity() {
             val intent = Intent(this, MainActivity::class.java)
             startActivity(intent)
             overridePendingTransition(R.anim.slide_up_enter, R.anim.slide_down_exit)
-            finish()
         }, 2500)
     }
 }

--- a/app/src/main/java/com/nbcamp/tripgo/view/home/HomeFragment.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/home/HomeFragment.kt
@@ -167,7 +167,7 @@ class HomeFragment : Fragment() {
         }
 
         isGPSAvailable.observe(viewLifecycleOwner) { status ->
-            if(status.first) {
+            if (status.first) {
                 isGpsOn = true
                 sharedViewModel.setLocationEvent()
                 return@observe
@@ -213,7 +213,7 @@ class HomeFragment : Fragment() {
         }
 
         sharedViewModel.eventSetLocation.observe(viewLifecycleOwner) {
-            if(isGpsOn.not()) {
+            if (isGpsOn.not()) {
                 return@observe
             }
             fusedLocationProviderClient.getCurrentLocation(
@@ -331,8 +331,8 @@ class HomeFragment : Fragment() {
     @Deprecated("Deprecated in Java")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-        if(requestCode == GPS_ON) {
-            if(resultCode == Activity.RESULT_OK) {
+        if (requestCode == GPS_ON) {
+            if (resultCode == Activity.RESULT_OK) {
                 isGpsOn = true
                 sharedViewModel.setLocationEvent()
                 return

--- a/app/src/main/java/com/nbcamp/tripgo/view/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/home/HomeViewModel.kt
@@ -26,13 +26,13 @@ import com.nbcamp.tripgo.view.home.uistate.HomeWeatherUiState
 import com.nbcamp.tripgo.view.home.valuetype.AreaCode
 import com.nbcamp.tripgo.view.home.valuetype.LatXLngY
 import com.nbcamp.tripgo.view.home.valuetype.ProvincePlaceEntity
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import java.lang.Math.PI
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.floor
@@ -370,7 +370,7 @@ class HomeViewModel(
             _isGPSAvailable.postValue(true to null)
             return@addOnSuccessListener
         }.addOnFailureListener { exception ->
-            if(exception is ResolvableApiException) {
+            if (exception is ResolvableApiException) {
                 _isGPSAvailable.postValue(false to exception)
                 return@addOnFailureListener
             }

--- a/app/src/main/java/com/nbcamp/tripgo/view/home/HomeViewModel.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/home/HomeViewModel.kt
@@ -26,13 +26,13 @@ import com.nbcamp.tripgo.view.home.uistate.HomeWeatherUiState
 import com.nbcamp.tripgo.view.home.valuetype.AreaCode
 import com.nbcamp.tripgo.view.home.valuetype.LatXLngY
 import com.nbcamp.tripgo.view.home.valuetype.ProvincePlaceEntity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.lang.Math.PI
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.floor

--- a/app/src/main/java/com/nbcamp/tripgo/view/home/uistate/HomeFestivalUiState.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/home/uistate/HomeFestivalUiState.kt
@@ -1,11 +1,14 @@
 package com.nbcamp.tripgo.view.home.uistate
 
+import android.os.Parcelable
 import com.nbcamp.tripgo.data.repository.model.FestivalEntity
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 data class HomeFestivalUiState(
     val list: List<FestivalEntity>?,
     val isLoading: Boolean
-) {
+): Parcelable {
 
     companion object {
         fun initialize() = HomeFestivalUiState(

--- a/app/src/main/java/com/nbcamp/tripgo/view/home/uistate/HomeFestivalUiState.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/home/uistate/HomeFestivalUiState.kt
@@ -8,7 +8,7 @@ import kotlinx.parcelize.Parcelize
 data class HomeFestivalUiState(
     val list: List<FestivalEntity>?,
     val isLoading: Boolean
-): Parcelable {
+) : Parcelable {
 
     companion object {
         fun initialize() = HomeFestivalUiState(

--- a/app/src/main/java/com/nbcamp/tripgo/view/home/uistate/HomeProvincePlaceUiState.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/home/uistate/HomeProvincePlaceUiState.kt
@@ -1,11 +1,14 @@
 package com.nbcamp.tripgo.view.home.uistate
 
+import android.os.Parcelable
 import com.nbcamp.tripgo.view.home.valuetype.ProvincePlaceEntity
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 data class HomeProvincePlaceUiState(
     val list: List<ProvincePlaceEntity>?,
     val isLoading: Boolean
-) {
+): Parcelable {
 
     companion object {
         fun initialize() = HomeProvincePlaceUiState(

--- a/app/src/main/java/com/nbcamp/tripgo/view/home/uistate/HomeProvincePlaceUiState.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/home/uistate/HomeProvincePlaceUiState.kt
@@ -8,7 +8,7 @@ import kotlinx.parcelize.Parcelize
 data class HomeProvincePlaceUiState(
     val list: List<ProvincePlaceEntity>?,
     val isLoading: Boolean
-): Parcelable {
+) : Parcelable {
 
     companion object {
         fun initialize() = HomeProvincePlaceUiState(

--- a/app/src/main/java/com/nbcamp/tripgo/view/main/MainActivity.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/main/MainActivity.kt
@@ -29,6 +29,8 @@ import com.nbcamp.tripgo.view.calendar.CalendarFragment
 import com.nbcamp.tripgo.view.calendar.CalendarViewModel
 import com.nbcamp.tripgo.view.calendar.CalendarViewModelFactory
 import com.nbcamp.tripgo.view.home.HomeFragment
+import com.nbcamp.tripgo.view.home.uistate.HomeFestivalUiState
+import com.nbcamp.tripgo.view.home.uistate.HomeProvincePlaceUiState
 import com.nbcamp.tripgo.view.home.valuetype.TourTheme
 import com.nbcamp.tripgo.view.login.LogInActivity
 import com.nbcamp.tripgo.view.mypage.MyPageFragment
@@ -94,6 +96,11 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    // splash에서 미리 넘겨준 데이터 모음
+    private lateinit var homeFestivalUiState: HomeFestivalUiState
+    private lateinit var homeProvincePlaceUiState: HomeProvincePlaceUiState
+
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
@@ -101,8 +108,23 @@ class MainActivity : AppCompatActivity() {
         loadingDialog = LoadingDialog(this)
         this.onBackPressedDispatcher.addCallback(this, callback)
 
+        initVariables()
         initViews()
         initViewModels()
+    }
+
+    private fun initVariables() {
+        homeFestivalUiState = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(FESTIVAL_EXTRA_KEY, HomeFestivalUiState::class.java)!!
+        } else {
+            intent.getParcelableExtra(FESTIVAL_EXTRA_KEY)!!
+        }
+        homeProvincePlaceUiState = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra(PROVINCE_EXTRA_KEY, HomeProvincePlaceUiState::class.java)!!
+        } else {
+            intent.getParcelableExtra(PROVINCE_EXTRA_KEY)!!
+        }
+        sharedViewModel.sendSplashData(homeFestivalUiState.list , homeProvincePlaceUiState.list)
     }
 
     private fun initViews() = with(binding) {
@@ -228,8 +250,6 @@ class MainActivity : AppCompatActivity() {
                         setText(setUserEvent.message)
                         setInvisible()
                     }
-                    println("firebaseUserMain:" + App.firebaseUser)
-                    println("kakaoUserMain: " + App.kakaoUser)
                 }
             }
         }
@@ -371,5 +391,10 @@ class MainActivity : AppCompatActivity() {
     override fun onDestroy() {
         super.onDestroy()
         ++App.prefs.feedbackCount
+    }
+
+    companion object {
+        const val FESTIVAL_EXTRA_KEY = "HomeFestivalUiState"
+        const val PROVINCE_EXTRA_KEY = "HomeProvincePlaceUiState"
     }
 }

--- a/app/src/main/java/com/nbcamp/tripgo/view/main/MainActivity.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/main/MainActivity.kt
@@ -100,7 +100,6 @@ class MainActivity : AppCompatActivity() {
     private lateinit var homeFestivalUiState: HomeFestivalUiState
     private lateinit var homeProvincePlaceUiState: HomeProvincePlaceUiState
 
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
@@ -124,7 +123,7 @@ class MainActivity : AppCompatActivity() {
         } else {
             intent.getParcelableExtra(PROVINCE_EXTRA_KEY)!!
         }
-        sharedViewModel.sendSplashData(homeFestivalUiState.list , homeProvincePlaceUiState.list)
+        sharedViewModel.sendSplashData(homeFestivalUiState.list, homeProvincePlaceUiState.list)
     }
 
     private fun initViews() = with(binding) {

--- a/app/src/main/java/com/nbcamp/tripgo/view/main/MainViewModel.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/main/MainViewModel.kt
@@ -8,6 +8,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.kakao.sdk.user.UserApiClient
 import com.nbcamp.tripgo.R
 import com.nbcamp.tripgo.data.repository.model.CalendarEntity
+import com.nbcamp.tripgo.data.repository.model.FestivalEntity
 import com.nbcamp.tripgo.util.SingleLiveEvent
 import com.nbcamp.tripgo.view.calendar.WritingType
 import com.nbcamp.tripgo.view.calendar.uistate.CalendarScheduleUiState
@@ -60,6 +61,11 @@ class MainViewModel : ViewModel() {
     private val _reviewDetailModel: MutableLiveData<ReviewWritingModel> = MutableLiveData()
     val reviewDetailModel: LiveData<ReviewWritingModel>
         get() = _reviewDetailModel
+
+    // 메인 화면 로딩 시간을 줄여주기 위해 스플래시에서 받아온 데이터
+    private val _dataFromSplash: MutableLiveData<Pair<List<FestivalEntity>, List<ProvincePlaceEntity>>> = MutableLiveData()
+    val dataFromSplash: MutableLiveData<Pair<List<FestivalEntity>, List<ProvincePlaceEntity>>>
+        get() = _dataFromSplash
 
     fun runThemeTourActivity(themeId: TourTheme) {
         _event.value = ThemeClickEvent.RunTourThemeActivity(themeId)
@@ -166,5 +172,15 @@ class MainViewModel : ViewModel() {
 
     fun setReviewDetailModel(model: ReviewWritingModel) {
         _reviewDetailModel.value = model
+    }
+
+    fun sendSplashData(
+        festivalList: List<FestivalEntity>?,
+        provinceList: List<ProvincePlaceEntity>?
+    ) {
+        if(festivalList == null || provinceList == null) {
+            return
+        }
+        _dataFromSplash.value = festivalList to provinceList
     }
 }

--- a/app/src/main/java/com/nbcamp/tripgo/view/main/MainViewModel.kt
+++ b/app/src/main/java/com/nbcamp/tripgo/view/main/MainViewModel.kt
@@ -178,7 +178,7 @@ class MainViewModel : ViewModel() {
         festivalList: List<FestivalEntity>?,
         provinceList: List<ProvincePlaceEntity>?
     ) {
-        if(festivalList == null || provinceList == null) {
+        if (festivalList == null || provinceList == null) {
             return
         }
         _dataFromSplash.value = festivalList to provinceList


### PR DESCRIPTION
## 구현 사항
- 스플래시 -> 홈화면을 통해 홈화면 데이터의 로딩 속도 개선 작업을 진행했습니다. (스플래시에서 데이터 가져오기)
- 스플래시 finish 태스크 관리법을 수정했습니다.
- 위치 정보가 필요한 관광지는 기존(홈화면에서 위치 권한 확인 후 가져오기)과 같으나, GPS 확인 방식이 인텐트 -> 다이얼로그로 수정되었습니다.

## 주요 변동 파일
- HomeFragment.kt
- HomeViewModel.kt
- SplashActivity.kt
---
close #212 